### PR TITLE
Refactor service configuration into ApplicationServiceExtensions

### DIFF
--- a/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
+++ b/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using SchoolMedicalServer.Abstractions.IServices;
+using SchoolMedicalServer.Infrastructure.Services;
+using SchoolMedicalServer.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace SchoolMedicalServer.Api.Boostraping
+{
+    public static class ApplicationServiceExtensions
+    {
+        public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters()
+                {
+                    ValidateIssuer = true,
+                    ValidIssuer = configuration["Jwt:Issuer"],
+                    ValidateAudience = true,
+                    ValidAudience = configuration["Jwt:Audience"],
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!))
+                };
+            });
+
+            services.AddDbContext<SchoolMedicalManagementContext>(options =>
+            {
+                options.UseSqlServer(configuration.GetConnectionString("ConnectionStrings:DBDefault"));
+            });
+            services.AddTransient<IAuthService, AuthService>();
+
+            return services;
+        }
+    }
+}

--- a/SchoolMedicalServer.Api/Program.cs
+++ b/SchoolMedicalServer.Api/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using SchoolMedicalServer.Abstractions.IServices;
+using SchoolMedicalServer.Api.Boostraping;
 using SchoolMedicalServer.Infrastructure;
 using SchoolMedicalServer.Infrastructure.Services;
 
@@ -21,27 +22,7 @@ namespace SchoolMedicalServer.Api
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
 
-            builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters()
-                {
-                    ValidateIssuer = true,
-                    ValidIssuer = builder.Configuration["Jwt:Issuer"],
-                    ValidateAudience = true,
-                    ValidAudience = builder.Configuration["Jwt:Audience"],
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
-                };
-            });
-
-            builder.Services.AddDbContext<SchoolMedicalManagementContext>(options =>
-            {
-                options.UseSqlServer(builder.Configuration.GetConnectionString("ConnectionStrings:DBDefault"));
-            });
-            builder.Services.AddTransient<IAuthService, AuthService>();
-
-
+            builder.Services.AddApplicationServices(builder.Configuration);
 
             var app = builder.Build();
 


### PR DESCRIPTION
Moved authentication and database context setup from `Program.cs` to a new static class `ApplicationServiceExtensions` in the `SchoolMedicalServer.Api.Boostraping` namespace. This change improves modularity and separation of concerns by encapsulating service registration logic in the `AddApplicationServices` method. The main program file is now simplified with a single call to `builder.Services.AddApplicationServices(builder.Configuration);`, enhancing readability.