### PR TITLE
Refactor connection string handling and add CORS policy

### DIFF
--- a/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
+++ b/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
@@ -27,8 +27,19 @@ namespace SchoolMedicalServer.Api.Boostraping
 
             services.AddDbContext<SchoolMedicalManagementContext>(options =>
             {
-                options.UseSqlServer(configuration.GetConnectionString("ConnectionStrings:DBDefault"));
+                options.UseSqlServer(configuration.GetConnectionString("DBDefault"));
             });
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy("AllowAllClients", builder =>
+                {
+                    builder.AllowAnyOrigin()
+                           .AllowAnyMethod()
+                           .AllowAnyHeader();
+                });
+            });
+
             services.AddTransient<IAuthService, AuthService>();
 
             return services;

--- a/SchoolMedicalServer.Api/Program.cs
+++ b/SchoolMedicalServer.Api/Program.cs
@@ -35,8 +35,9 @@ namespace SchoolMedicalServer.Api
 
             app.UseHttpsRedirection();
 
-            app.UseAuthorization();
+            app.UseCors("AllowAllClients");
 
+            app.UseAuthorization();
 
             app.MapControllers();
 

--- a/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
+++ b/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using SchoolMedicalServer.Abstractions.Entities;
 
 namespace SchoolMedicalServer.Infrastructure;
@@ -45,10 +46,6 @@ public partial class SchoolMedicalManagementContext : DbContext
     public virtual DbSet<VaccinationSchedule> VaccinationSchedules { get; set; }
 
     public virtual DbSet<VaccineDetail> VaccineDetails { get; set; }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
-        => optionsBuilder.UseSqlServer("Server=(local);Database= SchoolMedicalManagement;UID=sa;PWD=12345;TrustServerCertificate=True");
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/SchoolMedicalServer.Infrastructure/SchoolMedicalServer.Infrastructure.csproj
+++ b/SchoolMedicalServer.Infrastructure/SchoolMedicalServer.Infrastructure.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Refactor connection string handling and add CORS policy

- Updated connection string retrieval in ApplicationServiceExtensions.cs to simplify access.
- Added CORS policy "AllowAllClients" in Program.cs to permit all origins, methods, and headers.
- Removed hardcoded connection string in SchoolMedicalManagementContext.cs, shifting to configuration-based settings.
- Added package references for Microsoft.Extensions.Configuration and Microsoft.Extensions.Identity.Core in the project file.