### PR TITLE
Add HealthProfile entity and update related classes

### DIFF
--- a/SchoolMedicalServer.Abstractions/Entities/HealthCheckResult.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/HealthCheckResult.cs
@@ -31,6 +31,8 @@ public partial class HealthCheckResult
 
     public Guid? RecordedId { get; set; }
 
+    public virtual ICollection<HealthProfile> HealthProfiles { get; set; } = new List<HealthProfile>();
+
     public virtual HealthCheckSchedule? Schedule { get; set; }
 
     public virtual Student? Student { get; set; }

--- a/SchoolMedicalServer.Abstractions/Entities/HealthDeclaration.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/HealthDeclaration.cs
@@ -7,8 +7,6 @@ public partial class HealthDeclaration
 {
     public Guid HealthDeclarationId { get; set; }
 
-    public Guid? VaccineId { get; set; }
-
     public Guid? StudentId { get; set; }
 
     public DateOnly? DeclarationDate { get; set; }
@@ -24,6 +22,4 @@ public partial class HealthDeclaration
     public string? Notes { get; set; }
 
     public virtual Student? Student { get; set; }
-
-    public virtual VaccineDetail? Vaccine { get; set; }
 }

--- a/SchoolMedicalServer.Abstractions/Entities/HealthProfile.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/HealthProfile.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SchoolMedicalServer.Abstractions.Entities;
+
+public partial class HealthProfile
+{
+    public Guid HealthProfileId { get; set; }
+
+    public Guid? StudentId { get; set; }
+
+    public Guid? VaccinationResultId { get; set; }
+
+    public Guid? HealthCheckResultId { get; set; }
+
+    public DateTime? CreatedDate { get; set; }
+
+    public Guid? RecordedId { get; set; }
+
+    public string? Notes { get; set; }
+
+    public virtual HealthCheckResult? HealthCheckResult { get; set; }
+
+    public virtual Student? Student { get; set; }
+
+    public virtual VaccinationResult? VaccinationResult { get; set; }
+}

--- a/SchoolMedicalServer.Abstractions/Entities/Student.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/Student.cs
@@ -33,6 +33,8 @@ public partial class Student
 
     public virtual ICollection<HealthDeclaration> HealthDeclarations { get; set; } = new List<HealthDeclaration>();
 
+    public virtual ICollection<HealthProfile> HealthProfiles { get; set; } = new List<HealthProfile>();
+
     public virtual ICollection<MedicalEvent> MedicalEvents { get; set; } = new List<MedicalEvent>();
 
     public virtual ICollection<MedicalRegistration> MedicalRegistrations { get; set; } = new List<MedicalRegistration>();

--- a/SchoolMedicalServer.Abstractions/Entities/User.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/User.cs
@@ -9,13 +9,17 @@ public partial class User
 
     public int? RoleId { get; set; }
 
-    public string? FullName { get; set; } = null!;
+    public string? FullName { get; set; }
 
     public string PhoneNumber { get; set; } = null!;
 
     public string PasswordHash { get; set; } = null!;
 
     public string? EmailAddress { get; set; }
+
+    public string? AvatarUrl { get; set; }
+
+    public DateOnly? DayOfBirth { get; set; }
 
     public string? RefreshToken { get; set; }
 

--- a/SchoolMedicalServer.Abstractions/Entities/VaccinationResult.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/VaccinationResult.cs
@@ -29,6 +29,8 @@ public partial class VaccinationResult
 
     public Guid? RecordedId { get; set; }
 
+    public virtual ICollection<HealthProfile> HealthProfiles { get; set; } = new List<HealthProfile>();
+
     public virtual VaccinationSchedule? Schedule { get; set; }
 
     public virtual Student? Student { get; set; }

--- a/SchoolMedicalServer.Abstractions/Entities/VaccineDetail.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/VaccineDetail.cs
@@ -27,7 +27,5 @@ public partial class VaccineDetail
 
     public string? Description { get; set; }
 
-    public virtual ICollection<HealthDeclaration> HealthDeclarations { get; set; } = new List<HealthDeclaration>();
-
     public virtual ICollection<VaccinationSchedule> VaccinationSchedules { get; set; } = new List<VaccinationSchedule>();
 }

--- a/SchoolMedicalServer.Infrastructure/Migrations/20250526140502_Initial.Designer.cs
+++ b/SchoolMedicalServer.Infrastructure/Migrations/20250526140502_Initial.Designer.cs
@@ -12,8 +12,8 @@ using SchoolMedicalServer.Infrastructure;
 namespace SchoolMedicalServer.Infrastructure.Migrations
 {
     [DbContext(typeof(SchoolMedicalManagementContext))]
-    [Migration("20250525080600_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20250526140502_Initial")]
+    partial class Initial
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -56,7 +56,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("AppointmentId")
-                        .HasName("PK__Appointm__8ECDFCA22BCB7532");
+                        .HasName("PK__Appointm__8ECDFCA27FD29BEA");
 
                     b.HasIndex("StudentId");
 
@@ -115,7 +115,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("float");
 
                     b.HasKey("ResultId")
-                        .HasName("PK__HealthCh__976902280D4BD666");
+                        .HasName("PK__HealthCh__976902283B65C17C");
 
                     b.HasIndex("ScheduleId");
 
@@ -161,7 +161,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("ScheduleId")
-                        .HasName("PK__HealthCh__9C8A5B69FEDAE84D");
+                        .HasName("PK__HealthCh__9C8A5B69BE2ABA03");
 
                     b.HasIndex("StudentId");
 
@@ -203,18 +203,55 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("uniqueidentifier")
                         .HasColumnName("StudentID");
 
-                    b.Property<Guid?>("VaccineId")
-                        .HasColumnType("uniqueidentifier")
-                        .HasColumnName("VaccineID");
-
                     b.HasKey("HealthDeclarationId")
-                        .HasName("PK__HealthDe__327AAD7D84759B75");
+                        .HasName("PK__HealthDe__327AAD7D8F9E8268");
 
                     b.HasIndex("StudentId");
 
-                    b.HasIndex("VaccineId");
-
                     b.ToTable("HealthDeclaration", (string)null);
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthProfile", b =>
+                {
+                    b.Property<Guid>("HealthProfileId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("HealthProfileID");
+
+                    b.Property<DateTime?>("CreatedDate")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime")
+                        .HasDefaultValueSql("(getdate())");
+
+                    b.Property<Guid?>("HealthCheckResultId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("HealthCheckResultID");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
+                    b.Property<Guid?>("RecordedId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("RecordedID");
+
+                    b.Property<Guid?>("StudentId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("StudentID");
+
+                    b.Property<Guid?>("VaccinationResultId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("VaccinationResultID");
+
+                    b.HasKey("HealthProfileId")
+                        .HasName("PK__HealthPr__73C2C2B51D74B658");
+
+                    b.HasIndex("HealthCheckResultId");
+
+                    b.HasIndex("StudentId");
+
+                    b.HasIndex("VaccinationResultId");
+
+                    b.ToTable("HealthProfile", (string)null);
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.MedicalEvent", b =>
@@ -258,7 +295,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("EventId")
-                        .HasName("PK__MedicalE__7944C87040FECA9E");
+                        .HasName("PK__MedicalE__7944C8702997A560");
 
                     b.HasIndex("StudentId");
 
@@ -296,7 +333,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("nvarchar(20)");
 
                     b.HasKey("ItemId")
-                        .HasName("PK__MedicalI__727E83EB613E5005");
+                        .HasName("PK__MedicalI__727E83EBABA65EC3");
 
                     b.ToTable("MedicalInventory", (string)null);
                 });
@@ -337,7 +374,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("RegistrationId")
-                        .HasName("PK__MedicalR__6EF58830002FCD0C");
+                        .HasName("PK__MedicalR__6EF58830C8922221");
 
                     b.HasIndex("StudentId");
 
@@ -375,7 +412,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("int");
 
                     b.HasKey("RequestItemId")
-                        .HasName("PK__MedicalR__3F51AD779A9EAEC2");
+                        .HasName("PK__MedicalR__3F51AD77BE2FAFF0");
 
                     b.HasIndex("EventId");
 
@@ -417,7 +454,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("VaccineScheduleID");
 
                     b.HasKey("NotificationId")
-                        .HasName("PK__Notifica__20CF2E32D2FD02B9");
+                        .HasName("PK__Notifica__20CF2E32256F768A");
 
                     b.HasIndex("StudentId");
 
@@ -442,7 +479,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("varchar(10)");
 
                     b.HasKey("RoleId")
-                        .HasName("PK__Role__8AFACE3AB9E100EC");
+                        .HasName("PK__Role__8AFACE3A0F6D7D18");
 
                     b.ToTable("Role", (string)null);
                 });
@@ -495,7 +532,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("StudentId")
-                        .HasName("PK__Student__32C52A79E34805F8");
+                        .HasName("PK__Student__32C52A79AED3062C");
 
                     b.HasIndex("UserId");
 
@@ -507,6 +544,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.Property<Guid>("UserId")
                         .HasColumnType("uniqueidentifier")
                         .HasColumnName("UserID");
+
+                    b.Property<string>("AvatarUrl")
+                        .HasMaxLength(255)
+                        .IsUnicode(false)
+                        .HasColumnType("varchar(255)");
+
+                    b.Property<DateOnly?>("DayOfBirth")
+                        .HasColumnType("date");
 
                     b.Property<string>("EmailAddress")
                         .HasMaxLength(70)
@@ -542,11 +587,11 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("RoleID");
 
                     b.HasKey("UserId")
-                        .HasName("PK__User__1788CCACE402F678");
+                        .HasName("PK__User__1788CCAC7059EAEE");
 
                     b.HasIndex("RoleId");
 
-                    b.HasIndex(new[] { "PhoneNumber" }, "UQ__User__85FB4E3808A6DCD1")
+                    b.HasIndex(new[] { "PhoneNumber" }, "UQ__User__85FB4E38CF69A5AF")
                         .IsUnique();
 
                     b.ToTable("User", (string)null);
@@ -600,7 +645,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("date");
 
                     b.HasKey("VaccinationResultId")
-                        .HasName("PK__Vaccinat__12DE8FD94A304570");
+                        .HasName("PK__Vaccinat__12DE8FD91DB6B240");
 
                     b.HasIndex("ScheduleId");
 
@@ -646,7 +691,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("VaccineID");
 
                     b.HasKey("ScheduleId")
-                        .HasName("PK__Vaccinat__9C8A5B6975E3525E");
+                        .HasName("PK__Vaccinat__9C8A5B694492A7A5");
 
                     b.HasIndex("StudentId");
 
@@ -700,7 +745,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("nvarchar(50)");
 
                     b.HasKey("VaccineId")
-                        .HasName("PK__VaccineD__45DC68E9E9168660");
+                        .HasName("PK__VaccineD__45DC68E9F459710F");
 
                     b.ToTable("VaccineDetails");
                 });
@@ -727,12 +772,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.HealthCheckSchedule", "Schedule")
                         .WithMany("HealthCheckResults")
                         .HasForeignKey("ScheduleId")
-                        .HasConstraintName("FK__HealthChe__Sched__75A278F5");
+                        .HasConstraintName("FK__HealthChe__Sched__74AE54BC");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthCheckResults")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthChe__Stude__74AE54BC");
+                        .HasConstraintName("FK__HealthChe__Stude__73BA3083");
 
                     b.Navigation("Schedule");
 
@@ -744,12 +789,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthCheckSchedules")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthChe__Stude__70DDC3D8");
+                        .HasConstraintName("FK__HealthChe__Stude__6FE99F9F");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.User", "User")
                         .WithMany("HealthCheckSchedules")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("FK__HealthChe__UserI__71D1E811");
+                        .HasConstraintName("FK__HealthChe__UserI__70DDC3D8");
 
                     b.Navigation("Student");
 
@@ -761,16 +806,33 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthDeclarations")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthDec__Stude__66603565");
+                        .HasConstraintName("FK__HealthDec__Stude__656C112C");
 
-                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", "Vaccine")
-                        .WithMany("HealthDeclarations")
-                        .HasForeignKey("VaccineId")
-                        .HasConstraintName("FK__HealthDec__Vacci__656C112C");
+                    b.Navigation("Student");
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthProfile", b =>
+                {
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.HealthCheckResult", "HealthCheckResult")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("HealthCheckResultId")
+                        .HasConstraintName("FK__HealthPro__Healt__797309D9");
+
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("StudentId")
+                        .HasConstraintName("FK__HealthPro__Stude__778AC167");
+
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccinationResult", "VaccinationResult")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("VaccinationResultId")
+                        .HasConstraintName("FK__HealthPro__Vacci__787EE5A0");
+
+                    b.Navigation("HealthCheckResult");
 
                     b.Navigation("Student");
 
-                    b.Navigation("Vaccine");
+                    b.Navigation("VaccinationResult");
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.MedicalEvent", b =>
@@ -829,12 +891,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("Notifications")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Notificat__Stude__787EE5A0");
+                        .HasConstraintName("FK__Notificat__Stude__7D439ABD");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.User", "User")
                         .WithMany("Notifications")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("FK__Notificat__UserI__797309D9");
+                        .HasConstraintName("FK__Notificat__UserI__7E37BEF6");
 
                     b.Navigation("Student");
 
@@ -866,12 +928,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccinationSchedule", "Schedule")
                         .WithMany("VaccinationResults")
                         .HasForeignKey("ScheduleId")
-                        .HasConstraintName("FK__Vaccinati__Sched__6E01572D");
+                        .HasConstraintName("FK__Vaccinati__Sched__6D0D32F4");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("VaccinationResults")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Vaccinati__Stude__6D0D32F4");
+                        .HasConstraintName("FK__Vaccinati__Stude__6C190EBB");
 
                     b.Navigation("Schedule");
 
@@ -883,16 +945,21 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("VaccinationSchedules")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Vaccinati__Stude__693CA210");
+                        .HasConstraintName("FK__Vaccinati__Stude__68487DD7");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", "Vaccine")
                         .WithMany("VaccinationSchedules")
                         .HasForeignKey("VaccineId")
-                        .HasConstraintName("FK__Vaccinati__Vacci__6A30C649");
+                        .HasConstraintName("FK__Vaccinati__Vacci__693CA210");
 
                     b.Navigation("Student");
 
                     b.Navigation("Vaccine");
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthCheckResult", b =>
+                {
+                    b.Navigation("HealthProfiles");
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthCheckSchedule", b =>
@@ -925,6 +992,8 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
 
                     b.Navigation("HealthDeclarations");
 
+                    b.Navigation("HealthProfiles");
+
                     b.Navigation("MedicalEvents");
 
                     b.Navigation("MedicalRegistrations");
@@ -951,6 +1020,11 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.Navigation("Students");
                 });
 
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccinationResult", b =>
+                {
+                    b.Navigation("HealthProfiles");
+                });
+
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccinationSchedule", b =>
                 {
                     b.Navigation("VaccinationResults");
@@ -958,8 +1032,6 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", b =>
                 {
-                    b.Navigation("HealthDeclarations");
-
                     b.Navigation("VaccinationSchedules");
                 });
 #pragma warning restore 612, 618

--- a/SchoolMedicalServer.Infrastructure/Migrations/20250526140502_Initial.cs
+++ b/SchoolMedicalServer.Infrastructure/Migrations/20250526140502_Initial.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace SchoolMedicalServer.Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class Initial : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -25,7 +25,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__MedicalI__727E83EB613E5005", x => x.ItemID);
+                    table.PrimaryKey("PK__MedicalI__727E83EBABA65EC3", x => x.ItemID);
                 });
 
             migrationBuilder.CreateTable(
@@ -38,7 +38,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Role__8AFACE3AB9E100EC", x => x.RoleID);
+                    table.PrimaryKey("PK__Role__8AFACE3A0F6D7D18", x => x.RoleID);
                 });
 
             migrationBuilder.CreateTable(
@@ -59,7 +59,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__VaccineD__45DC68E9E9168660", x => x.VaccineID);
+                    table.PrimaryKey("PK__VaccineD__45DC68E9F459710F", x => x.VaccineID);
                 });
 
             migrationBuilder.CreateTable(
@@ -72,12 +72,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     PhoneNumber = table.Column<string>(type: "varchar(11)", unicode: false, maxLength: 11, nullable: false),
                     PasswordHash = table.Column<string>(type: "varchar(255)", unicode: false, maxLength: 255, nullable: false),
                     EmailAddress = table.Column<string>(type: "varchar(70)", unicode: false, maxLength: 70, nullable: true),
+                    AvatarUrl = table.Column<string>(type: "varchar(255)", unicode: false, maxLength: 255, nullable: true),
+                    DayOfBirth = table.Column<DateOnly>(type: "date", nullable: true),
                     RefreshToken = table.Column<string>(type: "varchar(255)", unicode: false, maxLength: 255, nullable: true),
                     RefreshTokenExpiryTime = table.Column<DateTime>(type: "datetime", nullable: true)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__User__1788CCACE402F678", x => x.UserID);
+                    table.PrimaryKey("PK__User__1788CCAC7059EAEE", x => x.UserID);
                     table.ForeignKey(
                         name: "FK__User__RoleID__4CA06362",
                         column: x => x.RoleID,
@@ -102,7 +104,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Student__32C52A79E34805F8", x => x.StudentID);
+                    table.PrimaryKey("PK__Student__32C52A79AED3062C", x => x.StudentID);
                     table.ForeignKey(
                         name: "FK__Student__UserID__4F7CD00D",
                         column: x => x.UserID,
@@ -125,7 +127,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Appointm__8ECDFCA22BCB7532", x => x.AppointmentID);
+                    table.PrimaryKey("PK__Appointm__8ECDFCA27FD29BEA", x => x.AppointmentID);
                     table.ForeignKey(
                         name: "FK__Appointme__Stude__52593CB8",
                         column: x => x.StudentID,
@@ -154,14 +156,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__HealthCh__9C8A5B69FEDAE84D", x => x.ScheduleID);
+                    table.PrimaryKey("PK__HealthCh__9C8A5B69BE2ABA03", x => x.ScheduleID);
                     table.ForeignKey(
-                        name: "FK__HealthChe__Stude__70DDC3D8",
+                        name: "FK__HealthChe__Stude__6FE99F9F",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
                     table.ForeignKey(
-                        name: "FK__HealthChe__UserI__71D1E811",
+                        name: "FK__HealthChe__UserI__70DDC3D8",
                         column: x => x.UserID,
                         principalTable: "User",
                         principalColumn: "UserID");
@@ -172,7 +174,6 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 columns: table => new
                 {
                     HealthDeclarationID = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    VaccineID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
                     StudentID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
                     DeclarationDate = table.Column<DateOnly>(type: "date", nullable: true),
                     ChronicDiseases = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -183,17 +184,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__HealthDe__327AAD7D84759B75", x => x.HealthDeclarationID);
+                    table.PrimaryKey("PK__HealthDe__327AAD7D8F9E8268", x => x.HealthDeclarationID);
                     table.ForeignKey(
-                        name: "FK__HealthDec__Stude__66603565",
+                        name: "FK__HealthDec__Stude__656C112C",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
-                    table.ForeignKey(
-                        name: "FK__HealthDec__Vacci__656C112C",
-                        column: x => x.VaccineID,
-                        principalTable: "VaccineDetails",
-                        principalColumn: "VaccineID");
                 });
 
             migrationBuilder.CreateTable(
@@ -213,7 +209,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__MedicalE__7944C87040FECA9E", x => x.EventID);
+                    table.PrimaryKey("PK__MedicalE__7944C8702997A560", x => x.EventID);
                     table.ForeignKey(
                         name: "FK__MedicalEv__Stude__59FA5E80",
                         column: x => x.StudentID,
@@ -242,7 +238,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__MedicalR__6EF58830002FCD0C", x => x.RegistrationID);
+                    table.PrimaryKey("PK__MedicalR__6EF58830C8922221", x => x.RegistrationID);
                     table.ForeignKey(
                         name: "FK__MedicalRe__Stude__5629CD9C",
                         column: x => x.StudentID,
@@ -270,14 +266,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Notifica__20CF2E32D2FD02B9", x => x.NotificationID);
+                    table.PrimaryKey("PK__Notifica__20CF2E32256F768A", x => x.NotificationID);
                     table.ForeignKey(
-                        name: "FK__Notificat__Stude__787EE5A0",
+                        name: "FK__Notificat__Stude__7D439ABD",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
                     table.ForeignKey(
-                        name: "FK__Notificat__UserI__797309D9",
+                        name: "FK__Notificat__UserI__7E37BEF6",
                         column: x => x.UserID,
                         principalTable: "User",
                         principalColumn: "UserID");
@@ -299,14 +295,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Vaccinat__9C8A5B6975E3525E", x => x.ScheduleID);
+                    table.PrimaryKey("PK__Vaccinat__9C8A5B694492A7A5", x => x.ScheduleID);
                     table.ForeignKey(
-                        name: "FK__Vaccinati__Stude__693CA210",
+                        name: "FK__Vaccinati__Stude__68487DD7",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
                     table.ForeignKey(
-                        name: "FK__Vaccinati__Vacci__6A30C649",
+                        name: "FK__Vaccinati__Vacci__693CA210",
                         column: x => x.VaccineID,
                         principalTable: "VaccineDetails",
                         principalColumn: "VaccineID");
@@ -332,14 +328,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__HealthCh__976902280D4BD666", x => x.ResultID);
+                    table.PrimaryKey("PK__HealthCh__976902283B65C17C", x => x.ResultID);
                     table.ForeignKey(
-                        name: "FK__HealthChe__Sched__75A278F5",
+                        name: "FK__HealthChe__Sched__74AE54BC",
                         column: x => x.ScheduleID,
                         principalTable: "HealthCheckSchedule",
                         principalColumn: "ScheduleID");
                     table.ForeignKey(
-                        name: "FK__HealthChe__Stude__74AE54BC",
+                        name: "FK__HealthChe__Stude__73BA3083",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
@@ -359,7 +355,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__MedicalR__3F51AD779A9EAEC2", x => x.RequestItemID);
+                    table.PrimaryKey("PK__MedicalR__3F51AD77BE2FAFF0", x => x.RequestItemID);
                     table.ForeignKey(
                         name: "FK__MedicalRe__Event__5FB337D6",
                         column: x => x.EventID,
@@ -391,17 +387,49 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK__Vaccinat__12DE8FD94A304570", x => x.VaccinationResultID);
+                    table.PrimaryKey("PK__Vaccinat__12DE8FD91DB6B240", x => x.VaccinationResultID);
                     table.ForeignKey(
-                        name: "FK__Vaccinati__Sched__6E01572D",
+                        name: "FK__Vaccinati__Sched__6D0D32F4",
                         column: x => x.ScheduleID,
                         principalTable: "VaccinationSchedule",
                         principalColumn: "ScheduleID");
                     table.ForeignKey(
-                        name: "FK__Vaccinati__Stude__6D0D32F4",
+                        name: "FK__Vaccinati__Stude__6C190EBB",
                         column: x => x.StudentID,
                         principalTable: "Student",
                         principalColumn: "StudentID");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "HealthProfile",
+                columns: table => new
+                {
+                    HealthProfileID = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    StudentID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    VaccinationResultID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    HealthCheckResultID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    CreatedDate = table.Column<DateTime>(type: "datetime", nullable: true, defaultValueSql: "(getdate())"),
+                    RecordedID = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK__HealthPr__73C2C2B51D74B658", x => x.HealthProfileID);
+                    table.ForeignKey(
+                        name: "FK__HealthPro__Healt__797309D9",
+                        column: x => x.HealthCheckResultID,
+                        principalTable: "HealthCheckResult",
+                        principalColumn: "ResultID");
+                    table.ForeignKey(
+                        name: "FK__HealthPro__Stude__778AC167",
+                        column: x => x.StudentID,
+                        principalTable: "Student",
+                        principalColumn: "StudentID");
+                    table.ForeignKey(
+                        name: "FK__HealthPro__Vacci__787EE5A0",
+                        column: x => x.VaccinationResultID,
+                        principalTable: "VaccinationResult",
+                        principalColumn: "VaccinationResultID");
                 });
 
             migrationBuilder.CreateIndex(
@@ -440,9 +468,19 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 column: "StudentID");
 
             migrationBuilder.CreateIndex(
-                name: "IX_HealthDeclaration_VaccineID",
-                table: "HealthDeclaration",
-                column: "VaccineID");
+                name: "IX_HealthProfile_HealthCheckResultID",
+                table: "HealthProfile",
+                column: "HealthCheckResultID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthProfile_StudentID",
+                table: "HealthProfile",
+                column: "StudentID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthProfile_VaccinationResultID",
+                table: "HealthProfile",
+                column: "VaccinationResultID");
 
             migrationBuilder.CreateIndex(
                 name: "IX_MedicalEvent_StudentID",
@@ -495,7 +533,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 column: "RoleID");
 
             migrationBuilder.CreateIndex(
-                name: "UQ__User__85FB4E3808A6DCD1",
+                name: "UQ__User__85FB4E38CF69A5AF",
                 table: "User",
                 column: "PhoneNumber",
                 unique: true);
@@ -528,10 +566,10 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 name: "Appointment");
 
             migrationBuilder.DropTable(
-                name: "HealthCheckResult");
+                name: "HealthDeclaration");
 
             migrationBuilder.DropTable(
-                name: "HealthDeclaration");
+                name: "HealthProfile");
 
             migrationBuilder.DropTable(
                 name: "MedicalRegistration");
@@ -543,16 +581,19 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                 name: "Notification");
 
             migrationBuilder.DropTable(
-                name: "VaccinationResult");
+                name: "HealthCheckResult");
 
             migrationBuilder.DropTable(
-                name: "HealthCheckSchedule");
+                name: "VaccinationResult");
 
             migrationBuilder.DropTable(
                 name: "MedicalEvent");
 
             migrationBuilder.DropTable(
                 name: "MedicalInventory");
+
+            migrationBuilder.DropTable(
+                name: "HealthCheckSchedule");
 
             migrationBuilder.DropTable(
                 name: "VaccinationSchedule");

--- a/SchoolMedicalServer.Infrastructure/Migrations/SchoolMedicalManagementContextModelSnapshot.cs
+++ b/SchoolMedicalServer.Infrastructure/Migrations/SchoolMedicalManagementContextModelSnapshot.cs
@@ -53,7 +53,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("AppointmentId")
-                        .HasName("PK__Appointm__8ECDFCA22BCB7532");
+                        .HasName("PK__Appointm__8ECDFCA27FD29BEA");
 
                     b.HasIndex("StudentId");
 
@@ -112,7 +112,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("float");
 
                     b.HasKey("ResultId")
-                        .HasName("PK__HealthCh__976902280D4BD666");
+                        .HasName("PK__HealthCh__976902283B65C17C");
 
                     b.HasIndex("ScheduleId");
 
@@ -158,7 +158,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("ScheduleId")
-                        .HasName("PK__HealthCh__9C8A5B69FEDAE84D");
+                        .HasName("PK__HealthCh__9C8A5B69BE2ABA03");
 
                     b.HasIndex("StudentId");
 
@@ -200,18 +200,55 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("uniqueidentifier")
                         .HasColumnName("StudentID");
 
-                    b.Property<Guid?>("VaccineId")
-                        .HasColumnType("uniqueidentifier")
-                        .HasColumnName("VaccineID");
-
                     b.HasKey("HealthDeclarationId")
-                        .HasName("PK__HealthDe__327AAD7D84759B75");
+                        .HasName("PK__HealthDe__327AAD7D8F9E8268");
 
                     b.HasIndex("StudentId");
 
-                    b.HasIndex("VaccineId");
-
                     b.ToTable("HealthDeclaration", (string)null);
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthProfile", b =>
+                {
+                    b.Property<Guid>("HealthProfileId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("HealthProfileID");
+
+                    b.Property<DateTime?>("CreatedDate")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime")
+                        .HasDefaultValueSql("(getdate())");
+
+                    b.Property<Guid?>("HealthCheckResultId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("HealthCheckResultID");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
+                    b.Property<Guid?>("RecordedId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("RecordedID");
+
+                    b.Property<Guid?>("StudentId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("StudentID");
+
+                    b.Property<Guid?>("VaccinationResultId")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("VaccinationResultID");
+
+                    b.HasKey("HealthProfileId")
+                        .HasName("PK__HealthPr__73C2C2B51D74B658");
+
+                    b.HasIndex("HealthCheckResultId");
+
+                    b.HasIndex("StudentId");
+
+                    b.HasIndex("VaccinationResultId");
+
+                    b.ToTable("HealthProfile", (string)null);
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.MedicalEvent", b =>
@@ -255,7 +292,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("EventId")
-                        .HasName("PK__MedicalE__7944C87040FECA9E");
+                        .HasName("PK__MedicalE__7944C8702997A560");
 
                     b.HasIndex("StudentId");
 
@@ -293,7 +330,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("nvarchar(20)");
 
                     b.HasKey("ItemId")
-                        .HasName("PK__MedicalI__727E83EB613E5005");
+                        .HasName("PK__MedicalI__727E83EBABA65EC3");
 
                     b.ToTable("MedicalInventory", (string)null);
                 });
@@ -334,7 +371,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("RegistrationId")
-                        .HasName("PK__MedicalR__6EF58830002FCD0C");
+                        .HasName("PK__MedicalR__6EF58830C8922221");
 
                     b.HasIndex("StudentId");
 
@@ -372,7 +409,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("int");
 
                     b.HasKey("RequestItemId")
-                        .HasName("PK__MedicalR__3F51AD779A9EAEC2");
+                        .HasName("PK__MedicalR__3F51AD77BE2FAFF0");
 
                     b.HasIndex("EventId");
 
@@ -414,7 +451,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("VaccineScheduleID");
 
                     b.HasKey("NotificationId")
-                        .HasName("PK__Notifica__20CF2E32D2FD02B9");
+                        .HasName("PK__Notifica__20CF2E32256F768A");
 
                     b.HasIndex("StudentId");
 
@@ -439,7 +476,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("varchar(10)");
 
                     b.HasKey("RoleId")
-                        .HasName("PK__Role__8AFACE3AB9E100EC");
+                        .HasName("PK__Role__8AFACE3A0F6D7D18");
 
                     b.ToTable("Role", (string)null);
                 });
@@ -492,7 +529,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("UserID");
 
                     b.HasKey("StudentId")
-                        .HasName("PK__Student__32C52A79E34805F8");
+                        .HasName("PK__Student__32C52A79AED3062C");
 
                     b.HasIndex("UserId");
 
@@ -504,6 +541,14 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.Property<Guid>("UserId")
                         .HasColumnType("uniqueidentifier")
                         .HasColumnName("UserID");
+
+                    b.Property<string>("AvatarUrl")
+                        .HasMaxLength(255)
+                        .IsUnicode(false)
+                        .HasColumnType("varchar(255)");
+
+                    b.Property<DateOnly?>("DayOfBirth")
+                        .HasColumnType("date");
 
                     b.Property<string>("EmailAddress")
                         .HasMaxLength(70)
@@ -539,11 +584,11 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("RoleID");
 
                     b.HasKey("UserId")
-                        .HasName("PK__User__1788CCACE402F678");
+                        .HasName("PK__User__1788CCAC7059EAEE");
 
                     b.HasIndex("RoleId");
 
-                    b.HasIndex(new[] { "PhoneNumber" }, "UQ__User__85FB4E3808A6DCD1")
+                    b.HasIndex(new[] { "PhoneNumber" }, "UQ__User__85FB4E38CF69A5AF")
                         .IsUnique();
 
                     b.ToTable("User", (string)null);
@@ -597,7 +642,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("date");
 
                     b.HasKey("VaccinationResultId")
-                        .HasName("PK__Vaccinat__12DE8FD94A304570");
+                        .HasName("PK__Vaccinat__12DE8FD91DB6B240");
 
                     b.HasIndex("ScheduleId");
 
@@ -643,7 +688,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnName("VaccineID");
 
                     b.HasKey("ScheduleId")
-                        .HasName("PK__Vaccinat__9C8A5B6975E3525E");
+                        .HasName("PK__Vaccinat__9C8A5B694492A7A5");
 
                     b.HasIndex("StudentId");
 
@@ -697,7 +742,7 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                         .HasColumnType("nvarchar(50)");
 
                     b.HasKey("VaccineId")
-                        .HasName("PK__VaccineD__45DC68E9E9168660");
+                        .HasName("PK__VaccineD__45DC68E9F459710F");
 
                     b.ToTable("VaccineDetails");
                 });
@@ -724,12 +769,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.HealthCheckSchedule", "Schedule")
                         .WithMany("HealthCheckResults")
                         .HasForeignKey("ScheduleId")
-                        .HasConstraintName("FK__HealthChe__Sched__75A278F5");
+                        .HasConstraintName("FK__HealthChe__Sched__74AE54BC");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthCheckResults")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthChe__Stude__74AE54BC");
+                        .HasConstraintName("FK__HealthChe__Stude__73BA3083");
 
                     b.Navigation("Schedule");
 
@@ -741,12 +786,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthCheckSchedules")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthChe__Stude__70DDC3D8");
+                        .HasConstraintName("FK__HealthChe__Stude__6FE99F9F");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.User", "User")
                         .WithMany("HealthCheckSchedules")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("FK__HealthChe__UserI__71D1E811");
+                        .HasConstraintName("FK__HealthChe__UserI__70DDC3D8");
 
                     b.Navigation("Student");
 
@@ -758,16 +803,33 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("HealthDeclarations")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__HealthDec__Stude__66603565");
+                        .HasConstraintName("FK__HealthDec__Stude__656C112C");
 
-                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", "Vaccine")
-                        .WithMany("HealthDeclarations")
-                        .HasForeignKey("VaccineId")
-                        .HasConstraintName("FK__HealthDec__Vacci__656C112C");
+                    b.Navigation("Student");
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthProfile", b =>
+                {
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.HealthCheckResult", "HealthCheckResult")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("HealthCheckResultId")
+                        .HasConstraintName("FK__HealthPro__Healt__797309D9");
+
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("StudentId")
+                        .HasConstraintName("FK__HealthPro__Stude__778AC167");
+
+                    b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccinationResult", "VaccinationResult")
+                        .WithMany("HealthProfiles")
+                        .HasForeignKey("VaccinationResultId")
+                        .HasConstraintName("FK__HealthPro__Vacci__787EE5A0");
+
+                    b.Navigation("HealthCheckResult");
 
                     b.Navigation("Student");
 
-                    b.Navigation("Vaccine");
+                    b.Navigation("VaccinationResult");
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.MedicalEvent", b =>
@@ -826,12 +888,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("Notifications")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Notificat__Stude__787EE5A0");
+                        .HasConstraintName("FK__Notificat__Stude__7D439ABD");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.User", "User")
                         .WithMany("Notifications")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("FK__Notificat__UserI__797309D9");
+                        .HasConstraintName("FK__Notificat__UserI__7E37BEF6");
 
                     b.Navigation("Student");
 
@@ -863,12 +925,12 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccinationSchedule", "Schedule")
                         .WithMany("VaccinationResults")
                         .HasForeignKey("ScheduleId")
-                        .HasConstraintName("FK__Vaccinati__Sched__6E01572D");
+                        .HasConstraintName("FK__Vaccinati__Sched__6D0D32F4");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("VaccinationResults")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Vaccinati__Stude__6D0D32F4");
+                        .HasConstraintName("FK__Vaccinati__Stude__6C190EBB");
 
                     b.Navigation("Schedule");
 
@@ -880,16 +942,21 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.Student", "Student")
                         .WithMany("VaccinationSchedules")
                         .HasForeignKey("StudentId")
-                        .HasConstraintName("FK__Vaccinati__Stude__693CA210");
+                        .HasConstraintName("FK__Vaccinati__Stude__68487DD7");
 
                     b.HasOne("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", "Vaccine")
                         .WithMany("VaccinationSchedules")
                         .HasForeignKey("VaccineId")
-                        .HasConstraintName("FK__Vaccinati__Vacci__6A30C649");
+                        .HasConstraintName("FK__Vaccinati__Vacci__693CA210");
 
                     b.Navigation("Student");
 
                     b.Navigation("Vaccine");
+                });
+
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthCheckResult", b =>
+                {
+                    b.Navigation("HealthProfiles");
                 });
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.HealthCheckSchedule", b =>
@@ -922,6 +989,8 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
 
                     b.Navigation("HealthDeclarations");
 
+                    b.Navigation("HealthProfiles");
+
                     b.Navigation("MedicalEvents");
 
                     b.Navigation("MedicalRegistrations");
@@ -948,6 +1017,11 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
                     b.Navigation("Students");
                 });
 
+            modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccinationResult", b =>
+                {
+                    b.Navigation("HealthProfiles");
+                });
+
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccinationSchedule", b =>
                 {
                     b.Navigation("VaccinationResults");
@@ -955,8 +1029,6 @@ namespace SchoolMedicalServer.Infrastructure.Migrations
 
             modelBuilder.Entity("SchoolMedicalServer.Abstractions.Entities.VaccineDetail", b =>
                 {
-                    b.Navigation("HealthDeclarations");
-
                     b.Navigation("VaccinationSchedules");
                 });
 #pragma warning restore 612, 618

--- a/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
+++ b/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using SchoolMedicalServer.Abstractions.Entities;
 
 namespace SchoolMedicalServer.Infrastructure;
@@ -24,6 +23,8 @@ public partial class SchoolMedicalManagementContext : DbContext
     public virtual DbSet<HealthCheckSchedule> HealthCheckSchedules { get; set; }
 
     public virtual DbSet<HealthDeclaration> HealthDeclarations { get; set; }
+
+    public virtual DbSet<HealthProfile> HealthProfiles { get; set; }
 
     public virtual DbSet<MedicalEvent> MedicalEvents { get; set; }
 
@@ -51,7 +52,7 @@ public partial class SchoolMedicalManagementContext : DbContext
     {
         modelBuilder.Entity<Appointment>(entity =>
         {
-            entity.HasKey(e => e.AppointmentId).HasName("PK__Appointm__8ECDFCA22BCB7532");
+            entity.HasKey(e => e.AppointmentId).HasName("PK__Appointm__8ECDFCA27FD29BEA");
 
             entity.ToTable("Appointment");
 
@@ -73,7 +74,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<HealthCheckResult>(entity =>
         {
-            entity.HasKey(e => e.ResultId).HasName("PK__HealthCh__976902280D4BD666");
+            entity.HasKey(e => e.ResultId).HasName("PK__HealthCh__976902283B65C17C");
 
             entity.ToTable("HealthCheckResult");
 
@@ -90,16 +91,16 @@ public partial class SchoolMedicalManagementContext : DbContext
 
             entity.HasOne(d => d.Schedule).WithMany(p => p.HealthCheckResults)
                 .HasForeignKey(d => d.ScheduleId)
-                .HasConstraintName("FK__HealthChe__Sched__75A278F5");
+                .HasConstraintName("FK__HealthChe__Sched__74AE54BC");
 
             entity.HasOne(d => d.Student).WithMany(p => p.HealthCheckResults)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__HealthChe__Stude__74AE54BC");
+                .HasConstraintName("FK__HealthChe__Stude__73BA3083");
         });
 
         modelBuilder.Entity<HealthCheckSchedule>(entity =>
         {
-            entity.HasKey(e => e.ScheduleId).HasName("PK__HealthCh__9C8A5B69FEDAE84D");
+            entity.HasKey(e => e.ScheduleId).HasName("PK__HealthCh__9C8A5B69BE2ABA03");
 
             entity.ToTable("HealthCheckSchedule");
 
@@ -115,16 +116,16 @@ public partial class SchoolMedicalManagementContext : DbContext
 
             entity.HasOne(d => d.Student).WithMany(p => p.HealthCheckSchedules)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__HealthChe__Stude__70DDC3D8");
+                .HasConstraintName("FK__HealthChe__Stude__6FE99F9F");
 
             entity.HasOne(d => d.User).WithMany(p => p.HealthCheckSchedules)
                 .HasForeignKey(d => d.UserId)
-                .HasConstraintName("FK__HealthChe__UserI__71D1E811");
+                .HasConstraintName("FK__HealthChe__UserI__70DDC3D8");
         });
 
         modelBuilder.Entity<HealthDeclaration>(entity =>
         {
-            entity.HasKey(e => e.HealthDeclarationId).HasName("PK__HealthDe__327AAD7D84759B75");
+            entity.HasKey(e => e.HealthDeclarationId).HasName("PK__HealthDe__327AAD7D8F9E8268");
 
             entity.ToTable("HealthDeclaration");
 
@@ -137,20 +138,46 @@ public partial class SchoolMedicalManagementContext : DbContext
             entity.Property(e => e.FoodAllergies).HasMaxLength(255);
             entity.Property(e => e.Notes).HasMaxLength(255);
             entity.Property(e => e.StudentId).HasColumnName("StudentID");
-            entity.Property(e => e.VaccineId).HasColumnName("VaccineID");
 
             entity.HasOne(d => d.Student).WithMany(p => p.HealthDeclarations)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__HealthDec__Stude__66603565");
+                .HasConstraintName("FK__HealthDec__Stude__656C112C");
+        });
 
-            entity.HasOne(d => d.Vaccine).WithMany(p => p.HealthDeclarations)
-                .HasForeignKey(d => d.VaccineId)
-                .HasConstraintName("FK__HealthDec__Vacci__656C112C");
+        modelBuilder.Entity<HealthProfile>(entity =>
+        {
+            entity.HasKey(e => e.HealthProfileId).HasName("PK__HealthPr__73C2C2B51D74B658");
+
+            entity.ToTable("HealthProfile");
+
+            entity.Property(e => e.HealthProfileId)
+                .ValueGeneratedNever()
+                .HasColumnName("HealthProfileID");
+            entity.Property(e => e.CreatedDate)
+                .HasDefaultValueSql("(getdate())")
+                .HasColumnType("datetime");
+            entity.Property(e => e.HealthCheckResultId).HasColumnName("HealthCheckResultID");
+            entity.Property(e => e.Notes).HasMaxLength(255);
+            entity.Property(e => e.RecordedId).HasColumnName("RecordedID");
+            entity.Property(e => e.StudentId).HasColumnName("StudentID");
+            entity.Property(e => e.VaccinationResultId).HasColumnName("VaccinationResultID");
+
+            entity.HasOne(d => d.HealthCheckResult).WithMany(p => p.HealthProfiles)
+                .HasForeignKey(d => d.HealthCheckResultId)
+                .HasConstraintName("FK__HealthPro__Healt__797309D9");
+
+            entity.HasOne(d => d.Student).WithMany(p => p.HealthProfiles)
+                .HasForeignKey(d => d.StudentId)
+                .HasConstraintName("FK__HealthPro__Stude__778AC167");
+
+            entity.HasOne(d => d.VaccinationResult).WithMany(p => p.HealthProfiles)
+                .HasForeignKey(d => d.VaccinationResultId)
+                .HasConstraintName("FK__HealthPro__Vacci__787EE5A0");
         });
 
         modelBuilder.Entity<MedicalEvent>(entity =>
         {
-            entity.HasKey(e => e.EventId).HasName("PK__MedicalE__7944C87040FECA9E");
+            entity.HasKey(e => e.EventId).HasName("PK__MedicalE__7944C8702997A560");
 
             entity.ToTable("MedicalEvent");
 
@@ -177,7 +204,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<MedicalInventory>(entity =>
         {
-            entity.HasKey(e => e.ItemId).HasName("PK__MedicalI__727E83EB613E5005");
+            entity.HasKey(e => e.ItemId).HasName("PK__MedicalI__727E83EBABA65EC3");
 
             entity.ToTable("MedicalInventory");
 
@@ -192,7 +219,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<MedicalRegistration>(entity =>
         {
-            entity.HasKey(e => e.RegistrationId).HasName("PK__MedicalR__6EF58830002FCD0C");
+            entity.HasKey(e => e.RegistrationId).HasName("PK__MedicalR__6EF58830C8922221");
 
             entity.ToTable("MedicalRegistration");
 
@@ -216,7 +243,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<MedicalRequest>(entity =>
         {
-            entity.HasKey(e => e.RequestItemId).HasName("PK__MedicalR__3F51AD779A9EAEC2");
+            entity.HasKey(e => e.RequestItemId).HasName("PK__MedicalR__3F51AD77BE2FAFF0");
 
             entity.ToTable("MedicalRequest");
 
@@ -239,7 +266,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<Notification>(entity =>
         {
-            entity.HasKey(e => e.NotificationId).HasName("PK__Notifica__20CF2E32D2FD02B9");
+            entity.HasKey(e => e.NotificationId).HasName("PK__Notifica__20CF2E32256F768A");
 
             entity.ToTable("Notification");
 
@@ -255,16 +282,16 @@ public partial class SchoolMedicalManagementContext : DbContext
 
             entity.HasOne(d => d.Student).WithMany(p => p.Notifications)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__Notificat__Stude__787EE5A0");
+                .HasConstraintName("FK__Notificat__Stude__7D439ABD");
 
             entity.HasOne(d => d.User).WithMany(p => p.Notifications)
                 .HasForeignKey(d => d.UserId)
-                .HasConstraintName("FK__Notificat__UserI__797309D9");
+                .HasConstraintName("FK__Notificat__UserI__7E37BEF6");
         });
 
         modelBuilder.Entity<Role>(entity =>
         {
-            entity.HasKey(e => e.RoleId).HasName("PK__Role__8AFACE3AB9E100EC");
+            entity.HasKey(e => e.RoleId).HasName("PK__Role__8AFACE3A0F6D7D18");
 
             entity.ToTable("Role");
 
@@ -276,7 +303,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<Student>(entity =>
         {
-            entity.HasKey(e => e.StudentId).HasName("PK__Student__32C52A79E34805F8");
+            entity.HasKey(e => e.StudentId).HasName("PK__Student__32C52A79AED3062C");
 
             entity.ToTable("Student");
 
@@ -308,15 +335,18 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<User>(entity =>
         {
-            entity.HasKey(e => e.UserId).HasName("PK__User__1788CCACE402F678");
+            entity.HasKey(e => e.UserId).HasName("PK__User__1788CCAC7059EAEE");
 
             entity.ToTable("User");
 
-            entity.HasIndex(e => e.PhoneNumber, "UQ__User__85FB4E3808A6DCD1").IsUnique();
+            entity.HasIndex(e => e.PhoneNumber, "UQ__User__85FB4E38CF69A5AF").IsUnique();
 
             entity.Property(e => e.UserId)
                 .ValueGeneratedNever()
                 .HasColumnName("UserID");
+            entity.Property(e => e.AvatarUrl)
+                .HasMaxLength(255)
+                .IsUnicode(false);
             entity.Property(e => e.EmailAddress)
                 .HasMaxLength(70)
                 .IsUnicode(false);
@@ -340,7 +370,7 @@ public partial class SchoolMedicalManagementContext : DbContext
 
         modelBuilder.Entity<VaccinationResult>(entity =>
         {
-            entity.HasKey(e => e.VaccinationResultId).HasName("PK__Vaccinat__12DE8FD94A304570");
+            entity.HasKey(e => e.VaccinationResultId).HasName("PK__Vaccinat__12DE8FD91DB6B240");
 
             entity.ToTable("VaccinationResult");
 
@@ -359,16 +389,16 @@ public partial class SchoolMedicalManagementContext : DbContext
 
             entity.HasOne(d => d.Schedule).WithMany(p => p.VaccinationResults)
                 .HasForeignKey(d => d.ScheduleId)
-                .HasConstraintName("FK__Vaccinati__Sched__6E01572D");
+                .HasConstraintName("FK__Vaccinati__Sched__6D0D32F4");
 
             entity.HasOne(d => d.Student).WithMany(p => p.VaccinationResults)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__Vaccinati__Stude__6D0D32F4");
+                .HasConstraintName("FK__Vaccinati__Stude__6C190EBB");
         });
 
         modelBuilder.Entity<VaccinationSchedule>(entity =>
         {
-            entity.HasKey(e => e.ScheduleId).HasName("PK__Vaccinat__9C8A5B6975E3525E");
+            entity.HasKey(e => e.ScheduleId).HasName("PK__Vaccinat__9C8A5B694492A7A5");
 
             entity.ToTable("VaccinationSchedule");
 
@@ -384,16 +414,16 @@ public partial class SchoolMedicalManagementContext : DbContext
 
             entity.HasOne(d => d.Student).WithMany(p => p.VaccinationSchedules)
                 .HasForeignKey(d => d.StudentId)
-                .HasConstraintName("FK__Vaccinati__Stude__693CA210");
+                .HasConstraintName("FK__Vaccinati__Stude__68487DD7");
 
             entity.HasOne(d => d.Vaccine).WithMany(p => p.VaccinationSchedules)
                 .HasForeignKey(d => d.VaccineId)
-                .HasConstraintName("FK__Vaccinati__Vacci__6A30C649");
+                .HasConstraintName("FK__Vaccinati__Vacci__693CA210");
         });
 
         modelBuilder.Entity<VaccineDetail>(entity =>
         {
-            entity.HasKey(e => e.VaccineId).HasName("PK__VaccineD__45DC68E9E9168660");
+            entity.HasKey(e => e.VaccineId).HasName("PK__VaccineD__45DC68E9F459710F");
 
             entity.Property(e => e.VaccineId)
                 .ValueGeneratedNever()


### PR DESCRIPTION
- Introduced `HealthProfile` class with relationships to `HealthCheckResult`, `Student`, and `VaccinationResult`.
- Updated `HealthCheckResult` to include a collection of `HealthProfiles`.
- Removed `VaccineId` from `HealthDeclaration` and adjusted relationships.
- Enhanced `Student` class with a collection of `HealthProfiles`.
- Updated `User` class to add `AvatarUrl` and `DayOfBirth` properties.
- Modified `VaccinationResult` to include a collection of `HealthProfiles`.
- Updated `InitialCreate` migration to include the new `HealthProfile` table.
- Adjusted `SchoolMedicalManagementContext` to include `HealthProfiles` DbSet.
- Reflected changes in the `ModelSnapshot` for the updated database schema.