### PR TITLE
Refactor user and health declaration management

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Account/RegisterStaffRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Account/RegisterStaffRequest.cs
@@ -6,6 +6,6 @@
         public string FullName { get; set; } = default!;
         public string Email { get; set; } = default!;
         public string Password { get; set; } = default!;
-        public string RoleId { get; set; } = default!;
+        public string RoleName { get; set; } = default!;
     }
 }

--- a/SchoolMedicalServer.Abstractions/Dtos/HealthDeclaration/HealthDeclarationRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/HealthDeclaration/HealthDeclarationRequest.cs
@@ -1,0 +1,33 @@
+﻿namespace SchoolMedicalServer.Abstractions.Dtos.HealthDeclaration
+{
+    public class HealthDeclarationRequest
+    {
+        public HealthDeclarationDtoRequest HealthDeclaration { get; set; } = default!;
+
+        public List<VaccinationDeclarationDtoRequest>? Vaccinations { get; set; }
+    }
+
+    public class HealthDeclarationDtoRequest
+    {
+        public DateOnly? DeclarationDate { get; set; }
+
+        public string? ChronicDiseases { get; set; }
+
+        public string? DrugAllergies { get; set; }
+
+        public string? FoodAllergies { get; set; }
+
+        public string? Notes { get; set; }
+    }
+
+    public class VaccinationDeclarationDtoRequest
+    {
+        public string VaccineName { get; set; } = default!;
+
+        public string? BatchNumber { get; set; }
+
+        public DateOnly? VaccinatedDate { get; set; }
+
+        public string? Notes { get; set; }
+    }
+}

--- a/SchoolMedicalServer.Abstractions/Dtos/HealthDeclaration/HealthDeclarationResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/HealthDeclaration/HealthDeclarationResponse.cs
@@ -1,0 +1,37 @@
+﻿namespace SchoolMedicalServer.Abstractions.Dtos.HealthDeclaration
+{
+    public class HealthDeclarationResponse
+    {
+        public HealthDeclarationDtoResponse HealthDeclaration { get; set; } = default!;
+
+        public List<VaccinationDeclarationDtoResponse>? Vaccinations { get; set; }
+    }
+
+    public class HealthDeclarationDtoResponse
+    {
+        public Guid HealthDeclarationId { get; set; }
+
+        public Guid? StudentId { get; set; }
+
+        public DateOnly? DeclarationDate { get; set; }
+
+        public string? ChronicDiseases { get; set; }
+
+        public string? DrugAllergies { get; set; }
+
+        public string? FoodAllergies { get; set; }
+
+        public string? Notes { get; set; }
+    }
+
+    public class VaccinationDeclarationDtoResponse
+    {
+        public string VaccineName { get; set; } = default!;
+
+        public string? BatchNumber { get; set; }
+
+        public DateOnly? VaccinatedDate { get; set; }
+
+        public string? Notes { get; set; }
+    }
+}

--- a/SchoolMedicalServer.Abstractions/Dtos/Pagination/PaginationRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Pagination/PaginationRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace SchoolMedicalServer.Abstractions.Dtos.Pagination
 {
-    public class PaginationRequest(int pageSize = 10, int pageIndex = 0)
+    public class PaginationRequest(int pageSize = 10, int pageIndex = 1)
     {
         public int PageSize { get; set; } = pageSize;
         public int PageIndex { get; set; } = pageIndex;

--- a/SchoolMedicalServer.Abstractions/Dtos/User/UserDTO.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/User/UserDTO.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SchoolMedicalServer.Abstractions.Dtos.User
+﻿namespace SchoolMedicalServer.Abstractions.Dtos.User
 {
     public class UserDto
     {

--- a/SchoolMedicalServer.Abstractions/Dtos/UserProfile/UserProfileRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/UserProfile/UserProfileRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace SchoolMedicalServer.Abstractions.Dtos.UserProfile
+{
+    public class UserProfileRequest
+    {
+        public string FullName { get; set; } = default!;
+
+        public DateOnly? DateOfBirth { get; set; }
+
+        public string? AvatarUrl { get; set; }
+
+        public string EmailAddress { get; set; } = default!;
+
+    }
+}

--- a/SchoolMedicalServer.Abstractions/Dtos/UserProfile/UserProfileResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/UserProfile/UserProfileResponse.cs
@@ -1,22 +1,22 @@
-﻿using SchoolMedicalServer.Abstractions.Entities;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace SchoolMedicalServer.Abstractions.Dtos.UserProfile
 {
-    public class UserProfileDto
+    public class UserProfileResponse
     {
         public string FullName { get; set; } = default!;
+
+        public string PhoneNumber { get; set; } = default!;
 
         public DateOnly? DateOfBirth { get; set; }
 
         public string? AvatarUrl { get; set; }
 
-        public string Email { get; set; } = default!;
+        public string EmailAddress { get; set; } = default!;
 
     }
 }

--- a/SchoolMedicalServer.Abstractions/Entities/HealthDeclaration.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/HealthDeclaration.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace SchoolMedicalServer.Abstractions.Entities;
+﻿namespace SchoolMedicalServer.Abstractions.Entities;
 
 public partial class HealthDeclaration
 {
@@ -17,9 +14,8 @@ public partial class HealthDeclaration
 
     public string? FoodAllergies { get; set; }
 
-    public string? AdministeredVaccines { get; set; }
-
     public string? Notes { get; set; }
 
     public virtual Student? Student { get; set; }
+    public virtual ICollection<VaccinationDeclaration> VaccinationDeclarations { get; set; } = new List<VaccinationDeclaration>();
 }

--- a/SchoolMedicalServer.Abstractions/Entities/VaccinationDeclaration.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/VaccinationDeclaration.cs
@@ -1,0 +1,13 @@
+﻿namespace SchoolMedicalServer.Abstractions.Entities
+{
+    public partial class VaccinationDeclaration
+    {
+        public Guid VaccinationDeclarationId { get; set; }
+        public Guid HealthDeclarationId { get; set; }
+        public string VaccineName { get; set; } = null!;
+        public string? BatchNumber { get; set; }
+        public DateOnly? VaccinatedDate { get; set; }
+        public string? Notes { get; set; }
+        public virtual HealthDeclaration HealthDeclaration { get; set; } = null!;
+    }
+}

--- a/SchoolMedicalServer.Abstractions/IServices/IAccountService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IAccountService.cs
@@ -2,7 +2,7 @@
 
 namespace SchoolMedicalServer.Abstractions.IServices
 {
-    public interface IAccountServices
+    public interface IAccountService
     {
         Task<List<AccountDto>> BatchCreateParentsAsync();
         Task<AccountDto?> RegisterStaffAsync(RegisterStaffRequest request);

--- a/SchoolMedicalServer.Abstractions/IServices/IAuthService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IAuthService.cs
@@ -3,7 +3,7 @@ using SchoolMedicalServer.Abstractions.Entities;
 
 namespace SchoolMedicalServer.Abstractions.IServices
 {
-    public interface IAuthServices
+    public interface IAuthService
     {
         Task<User?> ChangePasswordAsync(ChangePasswordRequest request);
         Task<TokensResponse?> LoginAsync(LoginRequest request);

--- a/SchoolMedicalServer.Abstractions/IServices/IHealthDeclarationService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IHealthDeclarationService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SchoolMedicalServer.Abstractions.Dtos.HealthDeclaration;
+
+namespace SchoolMedicalServer.Abstractions.IServices
+{
+    public interface IHealthDeclarationService
+    {
+        Task<bool> CreateHealthDeclarationAsync(Guid studentId, HealthDeclarationRequest request);
+        Task<HealthDeclarationResponse?> GetHealthDeclarationAsync(Guid studentId);
+    }
+}

--- a/SchoolMedicalServer.Abstractions/IServices/IUserProfileService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IUserProfileService.cs
@@ -5,7 +5,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
 {
     public interface IUserProfileService
     {
-        Task<UserProfileDto?> GetUserProfileByIdAsync(Guid userId);
-        Task<UserProfileDto?> UpdateUserProfileAsync(Guid userId, UserProfileDto dto);
+        Task<UserProfileResponse?> GetUserProfileByIdAsync(Guid userId);
+        Task<UserProfileResponse?> UpdateUserProfileAsync(Guid userId, UserProfileRequest dto);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IServices/IUserService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IUserService.cs
@@ -1,11 +1,13 @@
-﻿using SchoolMedicalServer.Abstractions.Dtos.User;
+﻿using SchoolMedicalServer.Abstractions.Dtos.Pagination;
+using SchoolMedicalServer.Abstractions.Dtos.User;
 
 namespace SchoolMedicalServer.Abstractions.IServices
 {
     public interface IUserService
     {
-        Task<List<UserDto>?> GetAllAsync();
+        Task<PaginationResponse<UserDto>> GetAllAsync(PaginationRequest paginationRequest);
         Task<UserDto?> GetUserAsync(Guid userId);
+        Task<bool> UpdateStatusUserAsync(Guid userid, bool status);
         Task<bool> UpdateUserAsync(Guid userid, UserDto request);
     }
 }

--- a/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
+++ b/SchoolMedicalServer.Api/Boostraping/ApplicationServiceExtensions.cs
@@ -5,6 +5,7 @@ using SchoolMedicalServer.Infrastructure.Services;
 using SchoolMedicalServer.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using SchoolMedicalServer.Api.Helpers.EmailHelper;
+using Microsoft.OpenApi.Models;
 
 namespace SchoolMedicalServer.Api.Boostraping
 {
@@ -12,6 +13,35 @@ namespace SchoolMedicalServer.Api.Boostraping
     {
         public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration configuration)
         {
+            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+            services.AddEndpointsApiExplorer();
+            services.AddSwaggerGen(options =>
+            {
+                options.SwaggerDoc("v1", new OpenApiInfo { Title = "School Medical API", Version = "v1" });
+                options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    Description = "JWT Authorization: Bearer {token}",
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.ApiKey,
+                    Scheme = "Bearer"
+                });
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                         new OpenApiSecurityScheme
+                         {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                         },
+                         Array.Empty<string>()
+                     }
+                });
+            });
+
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
             {
                 options.TokenValidationParameters = new TokenValidationParameters()
@@ -41,12 +71,15 @@ namespace SchoolMedicalServer.Api.Boostraping
                 });
             });
 
-            services.AddScoped<IAuthServices, AuthServices>();
-            services.AddTransient<IAccountServices, AccountServices>();
+            services.AddScoped<IAuthService, AuthService>();
+            services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<IEmailHelper, EmailHelper>();
 
             services.AddTransient<IUserService, UserService>();
             services.AddTransient<IUserProfileService, UserProfileService>();
+
+            services.AddScoped<IHealthDeclarationService, HealthDeclarationService>();
+
 
             return services;
         }

--- a/SchoolMedicalServer.Api/Controllers/Account/AccountController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Account/AccountController.cs
@@ -9,7 +9,7 @@ namespace SchoolMedicalServer.Api.Controllers.Account
 {
     [Route("api/accounts")]
     [ApiController]
-    public class AccountController(IAccountServices accountService, IEmailHelper emailHelper) : ControllerBase
+    public class AccountController(IAccountService accountService, IEmailHelper emailHelper) : ControllerBase
     {
         [HttpPost("register-staff")]
         [Authorize(Roles = "admin")]
@@ -26,8 +26,12 @@ namespace SchoolMedicalServer.Api.Controllers.Account
                 Body = $@"
                 <html>
                 <body>
-                    <h2>Xin chào!</h2>
+                    <h2Xin chào!</h2>
                     <p>{"Bạn đã nhận được email từ hệ thống quản lý y tế."}</p>
+                    <p>Thông tin tài khoản của bạn: {account.PhoneNumber}</p>
+                    <p>Mật khẩu: {account.Password}</p>
+                    <p>Vui lòng đăng nhập và thay đổi mật khẩu ngay sau khi nhận được email này.</p>
+                    <p>Chúng tôi khuyến nghị bạn sử dụng mật khẩu mạnh và không chia sẻ thông tin đăng nhập của mình với bất kỳ ai.</p>
                     <p>Trân trọng,<br/>Đội ngũ phát triển</p>
                 </body>
                 </html>"

--- a/SchoolMedicalServer.Api/Controllers/Authentication/AuthenticationController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Authentication/AuthenticationController.cs
@@ -8,7 +8,7 @@ namespace SchoolMedicalServer.Api.Controllers.Authentication
 {
     [Route("api/auth")]
     [ApiController]
-    public class AuthenticationController(IAuthServices authService) : ControllerBase
+    public class AuthenticationController(IAuthService authService) : ControllerBase
     {
 
         [HttpPost("login")]

--- a/SchoolMedicalServer.Api/Controllers/HealthDeclaration/HealthDeclarationController.cs
+++ b/SchoolMedicalServer.Api/Controllers/HealthDeclaration/HealthDeclarationController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SchoolMedicalServer.Abstractions.Dtos.HealthDeclaration;
+using SchoolMedicalServer.Abstractions.IServices;
+
+namespace SchoolMedicalServer.Api.Controllers.HealthDeclaration
+{
+    [Route("api")]
+    [ApiController]
+    public class HealthDeclarationController(IHealthDeclarationService service) : ControllerBase
+    {
+
+        [HttpGet("students/{studentId}/health-declarations")]
+        [Authorize(Roles = "parent")]
+        public async Task<IActionResult> GetHealthDeclaration(Guid studentId)
+        {
+
+            var response = await service.GetHealthDeclarationAsync(studentId);
+            if (response == null)
+            {
+                return NotFound();
+            }
+            return Ok(response);
+        }
+
+        [HttpPost("students/{studentId}/health-declarations")]
+        [Authorize(Roles = "parent")]
+        public async Task<IActionResult> RegisterHealthDeclaration(Guid studentId, HealthDeclarationRequest request)
+        {
+            var isCreated = await service.CreateHealthDeclarationAsync(studentId, request);
+            if (!isCreated)
+            {
+                return BadRequest();
+            }
+            return Ok();
+        }
+    }
+}

--- a/SchoolMedicalServer.Api/Controllers/User/UserController.cs
+++ b/SchoolMedicalServer.Api/Controllers/User/UserController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SchoolMedicalServer.Abstractions.Dtos.Pagination;
 using SchoolMedicalServer.Abstractions.Dtos.User;
 using SchoolMedicalServer.Abstractions.IServices;
 
@@ -12,10 +13,10 @@ namespace SchoolMedicalServer.Api.Controllers.User
 
         [HttpGet]
         [Authorize(Roles = "admin")]
-        public async Task<IActionResult> GetUsers()
+        public async Task<IActionResult> GetUsers([AsParameters] PaginationRequest paginationRequest)
         {
-            var users = await userService.GetAllAsync();
-            if (users == null || users.Count == 0)
+            var users = await userService.GetAllAsync(paginationRequest);
+            if (users == null)
             {
                 return NotFound("No users found.");
             }
@@ -41,9 +42,19 @@ namespace SchoolMedicalServer.Api.Controllers.User
             var isUpdated = await userService.UpdateUserAsync(userid, request);
             if (!isUpdated)
             {
-                return NotFound();
+                return BadRequest();
             }
             return Ok(isUpdated);
+        }
+
+        [HttpDelete("{userid}")]
+        [Authorize(Roles = "admin")]
+        public async Task<IActionResult> UpdateStatusUser(Guid userid, [FromBody] bool status)
+        {
+            var isBaned = await userService.UpdateStatusUserAsync(userid, status);
+            if (!isBaned)
+                return BadRequest();
+            return Ok(isBaned);
         }
     }
 }

--- a/SchoolMedicalServer.Api/Controllers/UserProfile/UsersProfileController.cs
+++ b/SchoolMedicalServer.Api/Controllers/UserProfile/UsersProfileController.cs
@@ -26,7 +26,7 @@ namespace SchoolMedicalServer.Api.Controllers.UserProfile
 
         [HttpPut("{userId}")]
         [Authorize]
-        public async Task<IActionResult> UpdateProfileAsync(Guid userId, [FromBody] UserProfileDto request)
+        public async Task<IActionResult> UpdateProfileAsync(Guid userId, [FromBody] UserProfileRequest request)
         {
             if (!ModelState.IsValid)
             {

--- a/SchoolMedicalServer.Api/Program.cs
+++ b/SchoolMedicalServer.Api/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.OpenApi.Models;
 using SchoolMedicalServer.Api.Boostraping;
 
 namespace SchoolMedicalServer.Api
@@ -11,9 +12,6 @@ namespace SchoolMedicalServer.Api
             // Add services to the container.
 
             builder.Services.AddControllers();
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
 
             builder.Services.AddApplicationServices(builder.Configuration);
 

--- a/SchoolMedicalServer.Api/appsettings.Development.json
+++ b/SchoolMedicalServer.Api/appsettings.Development.json
@@ -5,7 +5,6 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
-
     "ConnectionStrings": {
         "DBDefault": "Server=localhost;Initial Catalog=SchoolMedicalManagement;User ID=sa;Password=12345;Trusted_Connection=True;Trust Server Certificate=True"
     },
@@ -14,8 +13,9 @@
         "Issuer": "https://localhost:7009",
         "Audience": "https://localhost:7009"
     },
-    "Default": {
-        "Password": "123@123@123"
+    "DefaultAccountCreate": {
+        "Password": "123@123@123",
+        "RoleName": "parent"
     },
     "EmailHost": "smtp.gmail.com",
     "EmailPort": "587",

--- a/SchoolMedicalServer.Infrastructure/Migrations/20250527141021_VaccinationDeclarationTable_RemoveAdministeredVaccines.Designer.cs
+++ b/SchoolMedicalServer.Infrastructure/Migrations/20250527141021_VaccinationDeclarationTable_RemoveAdministeredVaccines.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SchoolMedicalServer.Infrastructure;
 
@@ -11,9 +12,11 @@ using SchoolMedicalServer.Infrastructure;
 namespace SchoolMedicalServer.Infrastructure.Migrations
 {
     [DbContext(typeof(SchoolMedicalManagementContext))]
-    partial class SchoolMedicalManagementContextModelSnapshot : ModelSnapshot
+    [Migration("20250527141021_VaccinationDeclarationTable_RemoveAdministeredVaccines")]
+    partial class VaccinationDeclarationTable_RemoveAdministeredVaccines
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SchoolMedicalServer.Infrastructure/Migrations/20250527141021_VaccinationDeclarationTable_RemoveAdministeredVaccines.cs
+++ b/SchoolMedicalServer.Infrastructure/Migrations/20250527141021_VaccinationDeclarationTable_RemoveAdministeredVaccines.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SchoolMedicalServer.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class VaccinationDeclarationTable_RemoveAdministeredVaccines : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdministeredVaccines",
+                table: "HealthDeclaration");
+
+            migrationBuilder.CreateTable(
+                name: "VaccinationDeclaration",
+                columns: table => new
+                {
+                    VaccinationDeclarationID = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    HealthDeclarationID = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    VaccineName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    BatchNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VaccinatedDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK__VaccinationDeclaration", x => x.VaccinationDeclarationID);
+                    table.ForeignKey(
+                        name: "FK_VaccinationDeclaration_HealthDeclaration",
+                        column: x => x.HealthDeclarationID,
+                        principalTable: "HealthDeclaration",
+                        principalColumn: "HealthDeclarationID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleID",
+                keyValue: 2,
+                column: "RoleName",
+                value: "nurse");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VaccinationDeclaration_HealthDeclarationID",
+                table: "VaccinationDeclaration",
+                column: "HealthDeclarationID");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VaccinationDeclaration");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AdministeredVaccines",
+                table: "HealthDeclaration",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleID",
+                keyValue: 2,
+                column: "RoleName",
+                value: "staff");
+        }
+    }
+}

--- a/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
+++ b/SchoolMedicalServer.Infrastructure/SchoolMedicalManagementContext.cs
@@ -47,6 +47,7 @@ public partial class SchoolMedicalManagementContext : DbContext
     public virtual DbSet<VaccinationSchedule> VaccinationSchedules { get; set; }
 
     public virtual DbSet<VaccineDetail> VaccineDetails { get; set; }
+    public virtual DbSet<VaccinationDeclaration> VaccinationDeclarations { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -132,7 +133,7 @@ public partial class SchoolMedicalManagementContext : DbContext
             entity.Property(e => e.HealthDeclarationId)
                 .ValueGeneratedNever()
                 .HasColumnName("HealthDeclarationID");
-            entity.Property(e => e.AdministeredVaccines).HasMaxLength(255);
+            //entity.Property(e => e.AdministeredVaccines).HasMaxLength(255);
             entity.Property(e => e.ChronicDiseases).HasMaxLength(255);
             entity.Property(e => e.DrugAllergies).HasMaxLength(255);
             entity.Property(e => e.FoodAllergies).HasMaxLength(255);
@@ -448,6 +449,27 @@ public partial class SchoolMedicalManagementContext : DbContext
             new Role { RoleId = 3, RoleName = "manager" },
             new Role { RoleId = 4, RoleName = "parent" }
         );
+
+        modelBuilder.Entity<VaccinationDeclaration>(entity =>
+        {
+            entity.HasKey(e => e.VaccinationDeclarationId).HasName("PK__VaccinationDeclaration");
+
+            entity.ToTable("VaccinationDeclaration");
+
+            entity.Property(e => e.VaccinationDeclarationId)
+                .ValueGeneratedNever()
+                .HasColumnName("VaccinationDeclarationID");
+
+            entity.Property(e => e.HealthDeclarationId).HasColumnName("HealthDeclarationID");
+            entity.Property(e => e.VaccineName).HasMaxLength(100);
+            entity.Property(e => e.BatchNumber).HasMaxLength(50);
+            entity.Property(e => e.Notes).HasMaxLength(255);
+
+            entity.HasOne(d => d.HealthDeclaration)
+                .WithMany(p => p.VaccinationDeclarations)
+                .HasForeignKey(d => d.HealthDeclarationId)
+                .HasConstraintName("FK_VaccinationDeclaration_HealthDeclaration");
+        });
 
         OnModelCreatingPartial(modelBuilder);
     }

--- a/SchoolMedicalServer.Infrastructure/Services/AuthService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AuthService.cs
@@ -11,7 +11,7 @@ using SchoolMedicalServer.Abstractions.IServices;
 
 namespace SchoolMedicalServer.Infrastructure.Services
 {
-    public class AuthServices(SchoolMedicalManagementContext context, IConfiguration configuration) : IAuthServices
+    public class AuthService(SchoolMedicalManagementContext context, IConfiguration configuration) : IAuthService
     {
         public async Task<TokensResponse?> LoginAsync(LoginRequest request)
         {
@@ -25,7 +25,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 return null;
             }
 
-            if (request.Password == configuration["Default:Password"])
+            if (request.Password == configuration["Default:Password"] || user.Status == false)
             {
                 return null;
             }

--- a/SchoolMedicalServer.Infrastructure/Services/HealthDeclarationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthDeclarationService.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SchoolMedicalServer.Abstractions.Dtos.HealthDeclaration;
+using SchoolMedicalServer.Abstractions.Entities;
+using SchoolMedicalServer.Abstractions.IServices;
+
+namespace SchoolMedicalServer.Infrastructure.Services
+{
+    public class HealthDeclarationService(SchoolMedicalManagementContext context) : IHealthDeclarationService
+    {
+        public async Task<bool> CreateHealthDeclarationAsync(Guid studentId, HealthDeclarationRequest request)
+        {
+            if (studentId == Guid.Empty)
+            {
+                return false;
+            }
+
+            if (request == null)
+            {
+                return false;
+            }
+
+            var student = await context.Students.FirstOrDefaultAsync(s => s.StudentId == studentId);
+            if (student == null)
+            {
+                return false;
+            }
+
+            var healthDeclarationId = Guid.NewGuid();
+            var healthDeclaration = new HealthDeclaration
+            {
+                HealthDeclarationId = healthDeclarationId,
+                StudentId = studentId,
+                DeclarationDate = request.HealthDeclaration.DeclarationDate ?? DateOnly.FromDateTime(DateTime.UtcNow),
+                ChronicDiseases = request.HealthDeclaration.ChronicDiseases,
+                DrugAllergies = request.HealthDeclaration.DrugAllergies ?? "",
+                FoodAllergies = request.HealthDeclaration.FoodAllergies ?? "",
+                Notes = request.HealthDeclaration.Notes ?? ""
+            };
+            context.HealthDeclarations.Add(healthDeclaration);
+            if (request.Vaccinations != null)
+            {
+                foreach (var vaccination in request.Vaccinations)
+                {
+                    var vaccinationDeclaration = new VaccinationDeclaration
+                    {
+                        HealthDeclarationId = healthDeclarationId,
+                        VaccinationDeclarationId = Guid.NewGuid(),
+                        VaccineName = vaccination.VaccineName,
+                        BatchNumber = vaccination.BatchNumber,
+                        VaccinatedDate = vaccination.VaccinatedDate,
+                        Notes = vaccination.Notes
+                    };
+                    context.VaccinationDeclarations.Add(vaccinationDeclaration);
+                }
+            }
+            try
+            {
+                await context.SaveChangesAsync();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public async Task<HealthDeclarationResponse?> GetHealthDeclarationAsync(Guid studentId)
+        {
+            if (studentId == Guid.Empty)
+            {
+                return null;
+            }
+            var healthDeclaration = await context.HealthDeclarations
+                .Include(h => h.VaccinationDeclarations)
+                .FirstOrDefaultAsync(h => h.StudentId == studentId);
+            if (healthDeclaration == null)
+            {
+                return null;
+            }
+
+            var healthDeclarationDto = new HealthDeclarationDtoResponse
+            {
+                HealthDeclarationId = healthDeclaration.HealthDeclarationId,
+                StudentId = healthDeclaration.StudentId,
+                DeclarationDate = healthDeclaration.DeclarationDate,
+                ChronicDiseases = healthDeclaration.ChronicDiseases,
+                DrugAllergies = healthDeclaration.DrugAllergies,
+                FoodAllergies = healthDeclaration.FoodAllergies,
+                Notes = healthDeclaration.Notes
+            };
+
+            var vaccineDeclarations = healthDeclaration.VaccinationDeclarations
+                .Select(v => new VaccinationDeclarationDtoResponse
+                {
+                    VaccineName = v.VaccineName,
+                    BatchNumber = v.BatchNumber,
+                    VaccinatedDate = v.VaccinatedDate,
+                    Notes = v.Notes
+                }).ToList() ?? [];
+
+            var response = new HealthDeclarationResponse()
+            {
+                HealthDeclaration = healthDeclarationDto,
+                Vaccinations = vaccineDeclarations,
+            };
+
+            if (response.HealthDeclaration == null)
+            {
+                return null;
+            }
+
+            return response;
+        }
+
+    }
+}

--- a/SchoolMedicalServer.Infrastructure/Services/UserProfileService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/UserProfileService.cs
@@ -5,15 +5,16 @@ namespace SchoolMedicalServer.Infrastructure.Services
 {
     public class UserProfileService(SchoolMedicalManagementContext context) : IUserProfileService
     {
-        public async Task<UserProfileDto?> GetUserProfileByIdAsync(Guid userId)
+        public async Task<UserProfileResponse?> GetUserProfileByIdAsync(Guid userId)
         {
             var user = await context.Users.FindAsync(userId);
             if (user == null) return null;
 
-            var response = new UserProfileDto
+            var response = new UserProfileResponse
             {
                 FullName = user.FullName!,
-                Email = user.EmailAddress!,
+                EmailAddress = user.EmailAddress!,
+                PhoneNumber = user.PhoneNumber,
                 DateOfBirth = user.DayOfBirth,
                 AvatarUrl = user.AvatarUrl
             };
@@ -21,23 +22,24 @@ namespace SchoolMedicalServer.Infrastructure.Services
             return response;
         }
 
-        public async Task<UserProfileDto?> UpdateUserProfileAsync(Guid userId, UserProfileDto dto)
+        public async Task<UserProfileResponse?> UpdateUserProfileAsync(Guid userId, UserProfileRequest dto)
         {
             var user = await context.Users.FindAsync(userId);
             if (user == null) return null;
 
             user.FullName = dto.FullName;
-            user.EmailAddress = dto.Email;
+            user.EmailAddress = dto.EmailAddress;
             user.DayOfBirth = dto.DateOfBirth;
             user.AvatarUrl = dto.AvatarUrl;
 
             context.Users.Update(user);
             await context.SaveChangesAsync();
 
-            var response = new UserProfileDto
+            var response = new UserProfileResponse
             {
                 FullName = user.FullName,
-                Email = user.EmailAddress,
+                EmailAddress = user.EmailAddress,
+                PhoneNumber = user.PhoneNumber,
                 DateOfBirth = user.DayOfBirth,
                 AvatarUrl = user.AvatarUrl
             };


### PR DESCRIPTION
- Replaced `RoleId` with `RoleName` in `RegisterStaffRequest`.
- Updated pagination default in `PaginationRequest` from 0 to 1.
- Cleaned up using directives in `UserDTO` and `UserProfileDto`.
- Removed `AdministeredVaccines` from `HealthDeclaration` and added `VaccinationDeclarations`.
- Renamed service interfaces to singular form (`IAccountService`, `IAuthService`).
- Updated `IUserProfileService` to use new response model.
- Modified `IUserService` to include pagination in `GetAllAsync`.
- Added Swagger/OpenAPI support in `ApplicationServiceExtensions`.
- Updated controllers to use new singular service interfaces.
- Introduced new request and response models for health declarations and user profiles.
- Created `VaccinationDeclaration` entity and corresponding migration.
- Updated `AccountService` and `AuthService` to implement new logic.
- Added `HealthDeclarationService` for managing health declarations.