### PR TITLE
Refactor password reset and student API endpoints

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Authentication/ResetPasswordRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Authentication/ResetPasswordRequest.cs
@@ -5,7 +5,7 @@ namespace SchoolMedicalServer.Abstractions.Dtos.Authentication
     public class ResetPasswordRequest
     {
         [Required]
-        public string Opt { get; set; } = default!;
+        public string Otp { get; set; } = default!;
         [Required]
         public string PhoneNumber { get; set; } = default!;
         [Required]

--- a/SchoolMedicalServer.Api/Controllers/Student/StudentController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Student/StudentController.cs
@@ -6,13 +6,13 @@ using SchoolMedicalServer.Abstractions.IServices;
 
 namespace SchoolMedicalServer.Api.Controllers.Student
 {
-    [Route("api/students")]
+    [Route("api")]
     [ApiController]
-    public class StudentController(IStudentService service) : ControllerBase    
+    public class StudentController(IStudentService service) : ControllerBase
     {
-        [HttpGet]
+        [HttpGet("students")]
         [Authorize(Roles = "admin, manager")]
-        public async Task<ActionResult<IEnumerable<StudentDto>>> GetAllStudents([FromQuery] PaginationRequest? paginationRequest)
+        public async Task<IActionResult> GetAllStudents([FromQuery] PaginationRequest? paginationRequest)
         {
             var students = await service.GetAllStudentsAsync(paginationRequest);
             if (students == null || !students.Items.Any())

--- a/SchoolMedicalServer.Infrastructure/Services/AuthService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AuthService.cs
@@ -149,7 +149,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
         public async Task<bool> ResetPasswordAsync(ResetPasswordRequest request)
         {
-            var user = await context.Users.FirstOrDefaultAsync(u => u.PhoneNumber == request.PhoneNumber);
+            var user = await context.Users.FirstOrDefaultAsync(u => u.PhoneNumber == request.PhoneNumber && u.Otp == request.Otp);
             if (user == null)
             {
                 return false;


### PR DESCRIPTION
- Updated `ResetPasswordRequest` to use `Otp` instead of `Opt`.
- Changed `StudentController` route from `"api/students"` to `"api"` and added `"students"` route for `GetAllStudents`.
- Simplified return type of `GetAllStudents` method to `Task<IActionResult>`.
- Enhanced security in `ResetPasswordAsync` by verifying both phone number and OTP.