### PR TITLE
Refactor null checks in MedicalRegistrationService

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
@@ -156,9 +156,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
                 MedicalRegistrationNurseApprovedResponse? nurseApprovedResponse = await GetNuserInforAsync(medicalRegistration.StaffNurseId, medicalRegistration);
 
-                if (details == null || studentInfo == null || parentInfo == null || nurseApprovedResponse == null) return null!;
+                if (details == null || studentInfo == null || parentInfo == null) return null!;
 
-                var response = GetResponse(medicalRegistration, details, studentInfo, parentInfo, nurseApprovedResponse);
+                var response = GetResponse(medicalRegistration, details, studentInfo, parentInfo, nurseApprovedResponse!);
 
                 result.Add(response);
             }


### PR DESCRIPTION
This pull request includes a minor change to the `CreateMedicalRegistrationAsync` method in `MedicalRegistrationService.cs`. The change improves null handling by modifying the null-check condition and ensuring that the `nurseApprovedResponse` parameter is explicitly treated as non-null when passed to the `GetResponse` method.Removed null check for nurseApprovedResponse in the conditional return statement. Updated the call to
GetResponse to use the null-forgiving operator,
asserting that nurseApprovedResponse will not be null.