### PR TITLE
Refactor vaccination scheduling and improve null handling

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleRequest.cs
@@ -7,8 +7,6 @@
         public string? Description { get; set; }
         public DateOnly? StartDate { get; set; }
         public DateOnly? EndDate { get; set; }
-        public DateTime? StartTime { get; set; }
-        public DateTime? EndTime { get; set; }
         public Guid CreatedBy { get; set; }
         public IEnumerable<VaccinationRoundRequestDto> VaccinationRounds { get; set; } = default!;
     }
@@ -18,6 +16,8 @@
         public string? RoundName { get; set; }
         public string? TargetGrade { get; set; }
         public string? Description { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? EndTime { get; set; }
         public Guid NurseId { get; set; }
         public DateOnly? StartDate { get; set; }
         public DateOnly? EndDate { get; set; }

--- a/SchoolMedicalServer.Test/AuthServiceDDTTest.cs
+++ b/SchoolMedicalServer.Test/AuthServiceDDTTest.cs
@@ -28,7 +28,7 @@ namespace SchoolMedicalServer.Test
             {
                 UserId = Guid.NewGuid(),
                 PhoneNumber = u.Phone,
-                PasswordHash = new PasswordHasher<User>().HashPassword(null, u.Password),
+                PasswordHash = new PasswordHasher<User>().HashPassword(null!, u.Password),
                 RoleId = adminRole.RoleId,
                 Status = true
             });

--- a/SchoolMedicalServer.Test/AuthServiceTest.cs
+++ b/SchoolMedicalServer.Test/AuthServiceTest.cs
@@ -27,7 +27,7 @@ namespace SchoolMedicalServer.Tests.Services
             {
                 UserId = Guid.NewGuid(),
                 PhoneNumber = "1234567890",
-                PasswordHash = new PasswordHasher<User>().HashPassword(null, "YourStr0ngPassw0rd!"),
+                PasswordHash = new PasswordHasher<User>().HashPassword(null!, "YourStr0ngPassw0rd!"),
                 RoleId = adminRole.RoleId,
                 Status = true
             };


### PR DESCRIPTION
This pull request includes changes to improve the structure of vaccination schedule data and updates to password hashing in test methods. The most important changes involve moving `StartTime` and `EndTime` properties from `VaccinationScheduleRequest` to `VaccinationRoundRequestDto` and ensuring non-nullable handling in password hashing.

### Changes to vaccination schedule data:

* [`SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleRequest.cs`](diffhunk://#diff-ecaf6a9dd9f5dd3c6380b619467f20ddd8da03e39cf02a4a01f6573e91c268a2L10-L11): Removed `StartTime` and `EndTime` properties from `VaccinationScheduleRequest` and added them to `VaccinationRoundRequestDto` to better align with the structure of vaccination rounds. [[1]](diffhunk://#diff-ecaf6a9dd9f5dd3c6380b619467f20ddd8da03e39cf02a4a01f6573e91c268a2L10-L11) [[2]](diffhunk://#diff-ecaf6a9dd9f5dd3c6380b619467f20ddd8da03e39cf02a4a01f6573e91c268a2R19-R20)

### Updates to password hashing in test methods:

* [`SchoolMedicalServer.Test/AuthServiceDDTTest.cs`](diffhunk://#diff-5ad82ab7b9cd776817afc9e81665292ac3b246226aa1d7df42c98529e8b34119L31-R31): Updated `PasswordHash` generation to use `null!` for stricter nullability compliance.
* [`SchoolMedicalServer.Test/AuthServiceTest.cs`](diffhunk://#diff-99162ff9f69acf65dd399b69ff21e9f8ca7be91efbb959fc078d4c710e36f52eL30-R30): Updated `PasswordHash` generation to use `null!` for stricter nullability compliance.Removed StartTime and EndTime from VaccinationScheduleRequest and added them to VaccinationRoundRequestDto for better time management. Updated PasswordHash assignments in AuthServiceDDTTest.cs and AuthServiceTest.cs to use the null-forgiving operator for improved null safety.