### PR TITLE
Add NurseId and date properties to vaccination schedules

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleDetailsResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleDetailsResponse.cs
@@ -15,6 +15,7 @@ namespace SchoolMedicalServer.Abstractions.Dtos.Vaccination.Schedules
         public string? Description { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
+        public Guid NurseId { get; set; }
         public bool Status { get; set; }
     }
 }

--- a/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Vaccination/Schedules/VaccinationScheduleResponse.cs
@@ -13,6 +13,9 @@
         public string? Description { get; set; }
         public DateOnly? ParentNotificationStartDate { get; set; }
         public DateOnly? ParentNotificationEndDate { get; set; }
+        public DateOnly? StartDate { get; set; }
+        public DateOnly? EndDate { get; set; }
+
 
         public bool Status { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
@@ -140,6 +140,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     ScheduleId = schedule.ScheduleId,
                     Title = schedule.Title,
                     Description = schedule.Description,
+                    StartDate = schedule.StartDate,
+                    EndDate = schedule.EndDate,
                     ParentNotificationStartDate = schedule.ParentNotificationStartDate,
                     ParentNotificationEndDate = schedule.ParentNotificationEndDate,
                     CreatedAt = schedule.CreatedAt,
@@ -160,6 +162,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                         Description = round.Description,
                         StartTime = round.StartTime,
                         EndTime = round.EndTime,
+                        NurseId = round.NurseId,
                         Status = round.Status
                     })],
                 VaccinationDetailsResponse = new VaccinationDetailsResponse


### PR DESCRIPTION
- Added `NurseId` property to `VaccinationScheduleDetailsResponse`.
- Introduced `StartDate` and `EndDate` properties to `VaccinationScheduleResponse`.
- Updated `VaccinationScheduleResponseDto` to include new date properties.
- Modified mapping in `VaccinationScheduleService` to include `NurseId`.