### PR TITLE
Implement soft-delete for medical inventory items

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/MedicalInventoryService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalInventoryService.cs
@@ -42,14 +42,15 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
             public async Task<MedicalInventoryResponse?> DeleteMedicalInventoryAsync(Guid itemId)
             {
-                var item = await medicalInventoryRepository.GetByIdAsync(itemId);
-                if (item == null) return null;
+            var item = await medicalInventoryRepository.GetByIdAsync(itemId);
+            if (item == null) return null;
 
-                medicalInventoryRepository.Delete(item);
-                await baseRepository.SaveChangesAsync();
+            item.Status = false;
+            medicalInventoryRepository.Update(item);
+            await baseRepository.SaveChangesAsync();
 
-                return ToMedicalInventoryResponse(item);
-            }
+            return ToMedicalInventoryResponse(item);
+        }
 
         public async Task<MedicalInventoryResponse?> GetMedicalInventoryByIdAsync(Guid itemId)
         {


### PR DESCRIPTION
This pull request updates the behavior of the `MedicalInventoryService` when handling item deletions by marking items as inactive instead of removing them from the database.

Changes to item deletion logic:

* [`SchoolMedicalServer.Infrastructure/Services/MedicalInventoryService.cs`](diffhunk://#diff-f2d3f29214da5cbcd7c0845cbe99ba5e7ea22243d4e15ba689f59240316e63b3L48-R49): Modified the `Delete` operation to set the `Status` property of the item to `false` and call `Update` instead of `Delete`, ensuring items are marked as inactive rather than being permanently removed.Updated the `DeleteMedicalInventoryAsync` method in the `MedicalInventoryService` class to change the deletion logic. Items are now marked as inactive by setting their status to `false` instead of being removed from the database, reflecting a shift to a soft-delete approach.