### PR TITLE
Update vaccine detail status instead of deleting

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationDetailsService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationDetailsService.cs
@@ -120,7 +120,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
             var vaccineDetail = await vacctionDetailsRepository.GetByIdAsync(id);
             if (vaccineDetail == null) return null!;
 
-            vacctionDetailsRepository.Delete(vaccineDetail);
+            vaccineDetail.Status = false;
+            vacctionDetailsRepository.Update(vaccineDetail);
             await baseRepository.SaveChangesAsync();
 
             return MapToResponse(vaccineDetail);


### PR DESCRIPTION
Modified `DeleteVaccineDetailAsync` in `VaccinationDetailsService` to set the status of a vaccine detail to `false` instead of removing it. Removed the call to the `Delete` method and added logic to update the `Status` property, followed by persisting the change with the `Update` method.