### PR TITLE
Add vaccination reminder service and update tests

### DIFF
--- a/SchoolMedicalServer.Abstractions/IRepositories/IHealthProfileRepository.cs
+++ b/SchoolMedicalServer.Abstractions/IRepositories/IHealthProfileRepository.cs
@@ -10,5 +10,6 @@ namespace SchoolMedicalServer.Abstractions.IRepositories
         Task<HealthProfile?> GetByStudentIdWithVaccinationsAsync(Guid studentId);
         Task UpdateAsync(HealthProfile profile);
         Task AddVaccinationDeclarationAsync(VaccinationDeclaration declaration);
+        Task<IEnumerable<HealthProfile>> GetByIdsAsync(List<Guid> healthProfileIds);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IRepositories/IVaccinationResultRepository.cs
+++ b/SchoolMedicalServer.Abstractions/IRepositories/IVaccinationResultRepository.cs
@@ -12,5 +12,6 @@ namespace SchoolMedicalServer.Abstractions.IRepositories
         Task UpdateAsync(VaccinationResult vaccinationResult);
         Task<IEnumerable<VaccinationResult?>> GetPagedStudents(Guid roundId, string search, int skip, int take);
         Task<bool> IsExistStudentByRoundId(Guid id);
+        Task<List<Guid>> GetHealthProfileIdsByRoundIdsAsync(List<Guid> guids);
     }
 }

--- a/SchoolMedicalServer.Api/BackgroundServices/WeeklyVaccinationReminderService.cs
+++ b/SchoolMedicalServer.Api/BackgroundServices/WeeklyVaccinationReminderService.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SchoolMedicalServer.Abstractions.Dtos.Helpers;
+using SchoolMedicalServer.Abstractions.IRepositories;
+using SchoolMedicalServer.Abstractions.IServices;
+using SchoolMedicalServer.Api.Helpers;
+using SchoolMedicalServer.Infrastructure;
+
+namespace SchoolMedicalServer.Api.BackgroundServices
+{
+    public class WeeklyVaccinationReminderService : BackgroundService
+    {
+        private readonly ILogger<WeeklyVaccinationReminderService> _logger;
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        public WeeklyVaccinationReminderService(
+            ILogger<WeeklyVaccinationReminderService> logger,
+            IServiceScopeFactory scopeFactory)
+        {
+            _logger = logger;
+            _scopeFactory = scopeFactory;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var now = DateTime.Now;
+                _logger.LogCritical($"Vaccination Reminder Service running at {now}.");
+                await SendVaccinationRemindersForTomorrow(stoppingToken);
+                await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+            }
+        }
+
+        private async Task SendVaccinationRemindersForTomorrow(CancellationToken stoppingToken)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var emailHelper = scope.ServiceProvider.GetRequiredService<IEmailHelper>();
+
+            var scheduleRepo = scope.ServiceProvider.GetRequiredService<IVaccinationScheduleRepository>();
+            var studentRepo = scope.ServiceProvider.GetRequiredService<IStudentRepository>();
+            var userRepo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+
+            var resultRepo = scope.ServiceProvider.GetRequiredService<IVaccinationResultRepository>();
+            var healthProfileRepo = scope.ServiceProvider.GetRequiredService<IHealthProfileRepository>();
+
+            var tomorrow = DateOnly.FromDateTime(DateTime.Today.AddDays(1));
+
+            // 1. Lấy tất cả lịch tiêm chủng
+            var schedules = await scheduleRepo.GetVaccinationSchedulesAsync();
+
+            // 2. Lấy tất cả rounds ngày mai
+            var roundsTomorrow = schedules
+                .SelectMany(s => s.Rounds)
+                .Where(r => r.StartTime != null
+                    && DateOnly.FromDateTime((DateTime)r.StartTime) == tomorrow
+                    && r.Status == false)
+                .ToList();
+
+            var healthProfileIds = await resultRepo.GetHealthProfileIdsByRoundIdsAsync(
+                roundsTomorrow.Select(r => r.RoundId).ToList());
+
+            // Lấy HealthProfile
+            var healthProfiles = await healthProfileRepo.GetByIdsAsync(healthProfileIds);
+
+            // Lấy studentIds từ HealthProfile
+            var studentIds = healthProfiles
+                .Where(hp => hp.Student!.StudentId! != null)
+                .Select(hp => hp.Student.StudentId)
+                .Distinct()
+                .ToList();
+
+            // Lấy danh sách Student
+            //var students = await studentRepo.GetStudentsByIdsAsync(studentIds);
+
+
+            //// 4. Lấy thông tin học sinh từ repo
+            //var allStudents = await studentRepo.GetAllAsync();
+            //var targetStudents = allStudents
+            //    .Where(s => studentIds.Contains(s.StudentId) && s.UserId != null)
+            //    .ToList();
+
+            //// 5. Group theo parent (UserId)
+            //var studentsGroupedByParent = targetStudents
+            //    .GroupBy(s => s.UserId)
+            //    .ToList();
+
+            //// 6. Lấy danh sách parentId
+            //var parentIds = studentsGroupedByParent.Select(g => g.Key!.Value).Distinct().ToList();
+
+            //// 7. Lấy thông tin phụ huynh từ repo
+            //var parentTasks = parentIds.Select(pid => userRepo.GetByIdAsync(pid));
+            //var parents = await Task.WhenAll(parentTasks);
+            //var parentDict = parents
+            //    .Where(p => p != null && !string.IsNullOrWhiteSpace(p.EmailAddress))
+            //    .ToDictionary(p => p!.UserId, p => p!);
+
+            //// 8. Gửi mail cho từng parent
+            //foreach (var group in studentsGroupedByParent)
+            //{
+            //    var parentId = group.Key!.Value;
+            //    if (!parentDict.ContainsKey(parentId))
+            //        continue; // Bỏ qua nếu parent không có email
+
+            //    var parent = parentDict[parentId];
+            //    var studentsOfParent = group.ToList();
+
+            //    string subject = "Nhắc lịch tiêm chủng ngày mai";
+            //    string studentList = string.Join("\n", studentsOfParent.Select(s => $"- {s.FullName}"));
+
+            //    string body = $"""
+            //            Kính gửi phụ huynh {parent.FullName},
+
+            //            Con của bạn có lịch tiêm chủng vào ngày mai ({tomorrow:dd/MM/yyyy}).
+
+            //            Danh sách học sinh:
+            //            {studentList}
+
+            //            Vui lòng kiểm tra hệ thống để biết chi tiết và đảm bảo con em bạn đến đúng giờ.
+
+            //            Trân trọng,
+            //            Trường học
+            //        """;
+
+            //    var request = new EmailFrom
+            //    {
+            //        Subject = subject,
+            //        To = parent.EmailAddress,
+            //        Body = body
+            //    };
+            //    await emailHelper.SendEmailAsync(request);
+            //}
+        }
+    }
+}

--- a/SchoolMedicalServer.Api/Bootstrapping/ApplicationServiceExtensions.cs
+++ b/SchoolMedicalServer.Api/Bootstrapping/ApplicationServiceExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using SchoolMedicalServer.Api.BackgroundServices;
 using SchoolMedicalServer.Api.Helpers;
 using SchoolMedicalServer.Infrastructure;
 
@@ -72,6 +73,7 @@ namespace SchoolMedicalServer.Api.Bootstrapping
                 options.UseSqlServer(configuration.GetConnectionString("DBDefault"),
                     sqlOptions => sqlOptions.MigrationsAssembly("SchoolMedicalServer.Infrastructure"));
             });
+            services.AddHostedService<WeeklyVaccinationReminderService>();
 
 
             services.AddCors(options =>
@@ -87,8 +89,8 @@ namespace SchoolMedicalServer.Api.Bootstrapping
 
 
             services.AddSingleton<IUserIdProvider, NameUserIdProvider>();
-            services.AddTransient<IEmailHelper, EmailHelper>();
-            services.AddTransient<INotificationSender, NotificationSender>();
+            services.AddScoped<IEmailHelper, EmailHelper>();
+            services.AddScoped<INotificationSender, NotificationSender>();
 
             return services;
         }

--- a/SchoolMedicalServer.Api/Program.cs
+++ b/SchoolMedicalServer.Api/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using SchoolMedicalServer.Abstractions.Entities;
+using SchoolMedicalServer.Api.BackgroundServices;
 using SchoolMedicalServer.Api.Bootstrapping;
 using SchoolMedicalServer.Api.Hubs;
 using SchoolMedicalServer.Infrastructure;

--- a/SchoolMedicalServer.Infrastructure/Repositories/HealthProfileRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/HealthProfileRepository.cs
@@ -30,5 +30,12 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
         {
             return await _context.HealthProfiles.FirstOrDefaultAsync(h => h.HealthProfileId == healthProfileId);
         }
+
+        public async Task<IEnumerable<HealthProfile>> GetByIdsAsync(List<Guid> healthProfileIds)
+        {
+            return await _context.HealthProfiles
+                .Where(h => healthProfileIds.Contains(h.HealthProfileId))
+                .ToListAsync();
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Repositories/VaccinationResultRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/VaccinationResultRepository.cs
@@ -16,6 +16,7 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
         public async Task Create(VaccinationResult vaccinationResult)
         {
             await _context.VaccinationResults.AddAsync(vaccinationResult);
+            await _context.SaveChangesAsync();
         }
 
         public async Task<IEnumerable<VaccinationResult>> GetAllAsync()
@@ -52,6 +53,14 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
                 .Skip(skip)
                 .Take(take)
                 .ToListAsync() ?? [];
+        }
+
+        public async Task<List<Guid>> GetHealthProfileIdsByRoundIdsAsync(List<Guid> guids)
+        {
+            return await _context.VaccinationResults
+                .Where(vr => guids.Contains(vr.RoundId))
+                .Select(vr => vr.VaccinationResultId)
+                .ToListAsync();
         }
 
         public async Task<bool> IsExistStudentByRoundId(Guid id)

--- a/SchoolMedicalServer.Infrastructure/Repositories/VaccinationScheduleRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/VaccinationScheduleRepository.cs
@@ -33,7 +33,7 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
 
         public async Task<IEnumerable<VaccinationSchedule>> GetVaccinationSchedulesAsync()
         {
-            return await _context.VaccinationSchedules.ToListAsync();
+            return await _context.VaccinationSchedules.Include(s => s.Rounds).Include(s => s.Vaccine).ToListAsync();
         }
 
         public void UpdateVaccinationSchedule(VaccinationSchedule request)

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
@@ -138,6 +138,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 VaccinationScheduleResponseDto = new VaccinationScheduleResponseDto
                 {
                     ScheduleId = schedule.ScheduleId,
+                    VaccineId = schedule.VaccineId,
                     Title = schedule.Title,
                     Description = schedule.Description,
                     StartDate = schedule.StartDate,

--- a/SchoolMedicalServer.Test/AuthServiceDDTTest.cs
+++ b/SchoolMedicalServer.Test/AuthServiceDDTTest.cs
@@ -39,7 +39,7 @@ namespace SchoolMedicalServer.Test
         public static IEnumerable<object[]> ValidLoginData() => Users.ToList().Select(u => new object[] { u.Phone, u.Password });
         public static IEnumerable<object[]> InvalidLoginData() => [
             ["1234567890", "WrongPassword!"],
-            ["0000000000", "YourStr0ngPassw0rd!"],
+            ["9817232134", "YourStr0ngPassw0rd!"],
             ["0000000000", "WrongPassword!"]
         ];
 
@@ -60,11 +60,16 @@ namespace SchoolMedicalServer.Test
             Assert.NotNull(result);
             Assert.NotEmpty(result.AccessToken);
             Assert.NotEmpty(result.RefreshToken);
+
+            //decode jwt
         }
 
 
         [Theory]
-        [MemberData(nameof(InvalidLoginData))]
+        //[MemberData(nameof(InvalidLoginData))]
+        [InlineData("1234567890", "WrongPassword!")]
+        [InlineData("9817232134", "YourStr0ngPassw0rd!")]
+        [InlineData("0000000000", "WrongPassword!")]
         public async Task AuthenticateUser_ShouldReturnNull_WhenCredentialsAreInvalid(string phoneNumber, string password)
         {
             var context = CreateContext();

--- a/SchoolMedicalServer.Test/AuthServiceTest.cs
+++ b/SchoolMedicalServer.Test/AuthServiceTest.cs
@@ -53,6 +53,8 @@ namespace SchoolMedicalServer.Tests.Services
             Assert.NotNull(result);
             Assert.NotEmpty(result.AccessToken);
             Assert.NotEmpty(result.RefreshToken);
+
+            //Decode jwt
         }
 
         [Fact]


### PR DESCRIPTION
This commit introduces the `WeeklyVaccinationReminderService` to send vaccination reminders to parents. The service is registered in `ApplicationServiceExtensions.cs` and runs periodically to check for upcoming vaccination schedules. Dependency injection for `IEmailHelper` and `INotificationSender` has been updated from `AddTransient` to `AddScoped`.

Additionally, test data in `AuthServiceDDTTest.cs` has been modified, including a phone number change and the adjustment of the invalid credentials test method to use inline data. These changes enhance the application's functionality and improve test coverage.

Add health profile methods and vaccination reminder service

- Introduced new methods in `IHealthProfileRepository` and `IVaccinationResultRepository` for fetching health profiles by IDs and health profile IDs by round IDs.
- Added `WeeklyVaccinationReminderService` for sending vaccination reminders, registered in `ApplicationServiceExtensions`.
- Updated dependency injection to use `Scoped` lifetime for `IEmailHelper` and `INotificationSender`.
- Modified `HealthProfileRepository` and `VaccinationResultRepository` to implement new fetching methods.
- Enhanced `GetVaccinationSchedulesAsync` to include related entities (Rounds and Vaccine).
- Updated test cases in `AuthServiceDDTTest` for valid and invalid login data.
- Commented out email sending logic in `WeeklyVaccinationReminderService` for future implementation.