### PR TITLE
Add health check and vaccination round validations

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Repositories/HealthCheckResultRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/HealthCheckResultRepository.cs
@@ -38,6 +38,7 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
         public async Task<IEnumerable<HealthCheckResult?>> GetByHealthProfileIdsAsync(IEnumerable<Guid> enumerable)
         {
             return await _context.HealthCheckResults
+                .Include(r => r.Round)
                 .Include(hcr => hcr.HealthProfile)
                 .ThenInclude(hp => hp!.Student)
                 .Where(hcr => enumerable.Contains(hcr.HealthProfileId))

--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
@@ -211,6 +211,11 @@ namespace SchoolMedicalServer.Infrastructure.Services
             {
                 return false;
             }
+            var results = await healthCheckResultRepository.GetAllStudentsInRound(roundId);
+            if (results.Any(r => r!.Status == false))
+            {
+                return false;
+            }
             round.Status = request;
             await healthCheckRoundRepository.UpdateHealthCheckRound(round);
             return true;

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
@@ -140,6 +140,11 @@ namespace SchoolMedicalServer.Infrastructure.Services
             {
                 return false;
             }
+            var results = await vaccinationResultRepository.GetAllStudentsInRound(roundId);
+            if (results.Any(r => r!.Vaccinated == false))
+            {
+                return false;
+            }
             round.Status = request;
             await vaccinationRound.UpdateVaccinationRound(round);
             return true;


### PR DESCRIPTION
- Implemented `GetByHealthProfileIdsAsync` in `HealthCheckResultRepository` for fetching health check results by profile IDs with eager loading.
- Added validation in `HealthCheckRoundService` to ensure no students have a `false` status before updating the round.
- Introduced similar validation in `VaccinationRoundService` to check for unvaccinated students before updating the vaccination round.