### PR TITLE
create get health-check-round by roundid

### DIFF
--- a/SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.cs
@@ -6,6 +6,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
     public interface IHealthCheckRoundService
     {
         Task<bool> CreateHealthCheckRoundByScheduleIdAsync(HealthCheckRoundRequest request);
+        Task<HealthCheckRoundResponse> GetHealthCheckRoundByIdAsync(Guid roundId);
         Task<PaginationResponse<HealthCheckRoundResponse>> GetHealthCheckRoundsByNurseIdAsync(Guid nurseId, PaginationRequest? pagination);
         Task<IEnumerable<HealthCheckRoundParentResponse>> GetHealthCheckRoundsByUserIdAsync(Guid userId, DateOnly? start, DateOnly? end);
         Task<PaginationResponse<HealthCheckRoundStudentResponse>> GetStudentsByHealthCheckRoundIdForManagerAsync(PaginationRequest? pagination, Guid roundId);

--- a/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.cs
+++ b/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.cs
@@ -107,5 +107,17 @@ namespace SchoolMedicalServer.Api.Controllers.HealthCheck
             }
             return Ok(healthCheckRounds);
         }
+
+        [HttpGet("health-check-rounds/{roundId}")]
+        [Authorize(Roles = "admin, manager, nurse")]
+        public async Task<IActionResult> GetHealthCheckRoundById(Guid roundId)
+        {
+            var healthCheckRound = await service.GetHealthCheckRoundByIdAsync(roundId);
+            if (healthCheckRound == null)
+            {
+                return NotFound(new { Message = "Health check round not found." });
+            }
+            return Ok(healthCheckRound);
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
@@ -265,5 +265,16 @@ namespace SchoolMedicalServer.Infrastructure.Services
             await healthCheckRoundRepository.UpdateHealthCheckRound(round);
             return true;
         }
+
+        public async Task<HealthCheckRoundResponse> GetHealthCheckRoundByIdAsync(Guid roundId)
+        {
+            if (roundId == Guid.Empty)
+                return null!;
+            var round = await healthCheckRoundRepository.GetHealthCheckRoundByIdAsync(roundId);
+            if (round is null)
+                return null!;
+            var res = await MapToDetailsResponse(round);
+            return res;
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve health check round details by ID. The changes include updates to the service interface, controller, and service implementation to support this functionality.

### New Feature: Retrieve Health Check Round by ID

#### Service Interface Update:
* Added the `GetHealthCheckRoundByIdAsync` method to the `IHealthCheckRoundService` interface for fetching health check round details using a round ID. (`SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.cs`, [SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.csR9](diffhunk://#diff-8f95456b740a3a1132d6be75e76527493055edc101c793f22ce380aa240ec72eR9))

#### Controller Update:
* Added a new endpoint `GET /health-check-rounds/{roundId}` in `HealthCheckRoundController` to handle requests for health check round details by ID. Includes role-based authorization for `admin`, `manager`, and `nurse`. (`SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.cs`, [SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.csR110-R121](diffhunk://#diff-cf53a8d0fdfc4fddb7c3d4a346f63ce545ed7ad3f66f72d027309f17462b9c92R110-R121))

#### Service Implementation Update:
* Implemented the `GetHealthCheckRoundByIdAsync` method in `HealthCheckRoundService` to retrieve health check round details from the repository, validate the round ID, and map the response. (`SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs`, [SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.csR268-R278](diffhunk://#diff-a5a1e4ec656da9acd643be02fff3d4515455b87fd27b64a4df1cf683395f65a3R268-R278))