### PR TITLE
Update RecordedId assignment in HealthCheckScheduleService

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckScheduleService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckScheduleService.cs
@@ -80,7 +80,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                         BloodPressure = null,
                         Status = false,
                         Notes = null,
-                        RecordedId = schedule.CreatedBy
+                        RecordedId = round.NurseId
                     };
                     await resultRepository.Create(result);
                     toParents.Add(new NotificationRequest


### PR DESCRIPTION
Changed RecordedId to use round.NurseId instead of schedule.CreatedBy to better reflect the source of the ID.