### PR TITLE
Expand authorization for health check results endpoint

### DIFF
--- a/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckResultController.cs
+++ b/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckResultController.cs
@@ -51,7 +51,7 @@ namespace SchoolMedicalServer.Api.Controllers.HealthCheck
         }
 
         [HttpGet("health-check-results/{resultId}")]
-        [Authorize(Roles = "admin, manager, nurse")]
+        [Authorize(Roles = "admin, manager, nurse, parent")]
         public async Task<IActionResult> GetHealthCheckResult(Guid resultId)
         {
             var result = await service.GetHealthCheckResultAsync(resultId);


### PR DESCRIPTION
Updated the `GetHealthCheckResult` method in the
`HealthCheckResultController` to include the "parent" role in the authorization attribute, allowing parents to access health check results alongside admins, managers, and nurses.