### PR TITLE
Add medical request handling and refactor services

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/MedicalEvent/MedicalRequestResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/MedicalEvent/MedicalRequestResponse.cs
@@ -1,0 +1,29 @@
+﻿namespace SchoolMedicalServer.Abstractions.Dtos.MedicalEvent
+{
+    public class MedicalRequestResponse
+    {
+        public EventInfo EventInfo { get; set; } = new();
+        public NurseInfo NurseInfo { get; set; } = new();
+        public MedicalInfo MedicalInfo { get; set; } = new();
+    }
+
+    public class EventInfo
+    {
+        public Guid EventId { get; set; }
+    }
+
+    public class NurseInfo
+    {
+        public Guid NurseId { get; set; }
+        public string FullName { get; set; } = string.Empty;
+    }
+
+    public class MedicalInfo
+    {
+        public Guid RequestId { get; set; }
+        public Guid? ItemId { get; set; }
+        public string? ItemName { get; set; }
+        public int? RequestQuantity { get; set; }
+        public DateOnly? RequestDate { get; set; }
+    }
+}

--- a/SchoolMedicalServer.Abstractions/Entities/MedicalRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/MedicalRequest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace SchoolMedicalServer.Abstractions.Entities;
+﻿namespace SchoolMedicalServer.Abstractions.Entities;
 
 public partial class MedicalRequest
 {

--- a/SchoolMedicalServer.Abstractions/IRepositories/IMedicalRequestRepository.cs
+++ b/SchoolMedicalServer.Abstractions/IRepositories/IMedicalRequestRepository.cs
@@ -7,5 +7,7 @@ namespace SchoolMedicalServer.Abstractions.IRepositories
     {
         Task<List<MedicalRequestDtoResponse>> GetByEventIdAsync(Guid eventId);
         Task AddRangeAsync(List<MedicalRequest> requests);
+        Task<int> CountAsync();
+        Task<IEnumerable<MedicalRequest>> GetMedicalRequestsAsync(int pageSize, int skip, string? search);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IServices/IMedicalRequestService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IMedicalRequestService.cs
@@ -1,0 +1,10 @@
+﻿using SchoolMedicalServer.Abstractions.Dtos.MedicalEvent;
+using SchoolMedicalServer.Abstractions.Dtos.Pagination;
+
+namespace SchoolMedicalServer.Abstractions.IServices
+{
+    public interface IMedicalRequestService
+    {
+        Task<PaginationResponse<MedicalRequestResponse>> GetMedicalRequestsAsync(PaginationRequest? pagination);
+    }
+}

--- a/SchoolMedicalServer.Api/Bootstrapping/ServiceServiceCollectionExtensions.cs
+++ b/SchoolMedicalServer.Api/Bootstrapping/ServiceServiceCollectionExtensions.cs
@@ -8,16 +8,16 @@ namespace SchoolMedicalServer.Api.Bootstrapping
         public static IServiceCollection AddServices(this IServiceCollection services)
         {
             services.AddScoped<IAuthService, AuthService>();
-            services.AddTransient<IAccountService, AccountService>();
-            services.AddTransient<IUserService, UserService>();
-            services.AddTransient<IUserProfileService, UserProfileService>();
+            services.AddScoped<IAccountService, AccountService>();
+            services.AddScoped<IUserService, UserService>();
+            services.AddScoped<IUserProfileService, UserProfileService>();
             services.AddScoped<IHealthProfileDeclarationService, HealthProfileDeclarationService>();
             services.AddScoped<IAppointmentService, AppointmentService>();
             services.AddScoped<IParentStudentService, ParentStudentService>();
-            services.AddTransient<IFileService, FileService>();
+            services.AddScoped<IFileService, FileService>();
             services.AddScoped<IStudentService, StudentService>();
-            services.AddTransient<IMedicalRegistrationService, MedicalRegistrationService>();
-            services.AddTransient<IMedicalEventService, MedicalEventService>();
+            services.AddScoped<IMedicalRegistrationService, MedicalRegistrationService>();
+            services.AddScoped<IMedicalEventService, MedicalEventService>();
             services.AddScoped<IMedicalInventoryService, MedicalInventoryService>();
             services.AddScoped<INotificationService, NotificationService>();
             services.AddScoped<IVaccinationDetailsService, VaccinationDetailsService>();
@@ -27,6 +27,7 @@ namespace SchoolMedicalServer.Api.Bootstrapping
             services.AddScoped<IHealthCheckScheduleService, HealthCheckScheduleService>();
             services.AddScoped<IHealthCheckResultService, HealthCheckResultService>();
             services.AddScoped<IHealthCheckRoundService, HealthCheckRoundService>();
+            services.AddScoped<IMedicalRequestService, MedicalRequestService>();
             return services;
         }
     }

--- a/SchoolMedicalServer.Api/Controllers/MedicalEvent/MedicalRequestController.cs
+++ b/SchoolMedicalServer.Api/Controllers/MedicalEvent/MedicalRequestController.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SchoolMedicalServer.Abstractions.Dtos.Pagination;
+using SchoolMedicalServer.Abstractions.IServices;
+
+namespace SchoolMedicalServer.Api.Controllers.MedicalEvent
+{
+    [Route("api")]
+    [ApiController]
+    public class MedicalRequestController(IMedicalRequestService service) : ControllerBase
+    {
+        [HttpGet("medical-requests")]
+        //[Authorize(Roles = "admin, manager")]
+        public async Task<IActionResult> GetMedicalRequest([FromQuery] PaginationRequest? pagination)
+        {
+            var results = await service.GetMedicalRequestsAsync(pagination);
+            if (results == null)
+            {
+                return NotFound(new { Message = "No medical requests found." });
+            }
+            return Ok(results);
+        }
+    }
+}

--- a/SchoolMedicalServer.Infrastructure/Repositories/MedicalRequestRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/MedicalRequestRepository.cs
@@ -27,5 +27,27 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
 
         public async Task AddRangeAsync(List<MedicalRequest> requests)
             => await context.MedicalRequests.AddRangeAsync(requests);
+
+        public async Task<int> CountAsync()
+        {
+            return await context.MedicalRequests
+                .AsNoTracking()
+                .CountAsync();
+        }
+
+        public async Task<IEnumerable<MedicalRequest>> GetMedicalRequestsAsync(int pageSize, int skip, string? search)
+        {
+            return await context.MedicalRequests
+                .Include(r => r.Item)
+                .Include(r => r.Event)
+                .Where(r => string.IsNullOrEmpty(search) ||
+                            r.Item!.ItemName!.Contains(search) ||
+                            r.Purpose!.Contains(search))
+                .OrderByDescending(r => r.RequestDate)
+                .Skip(skip)
+                .Take(pageSize)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
@@ -1,4 +1,3 @@
-using Azure.Core;
 using SchoolMedicalServer.Abstractions.Dtos.Appointment;
 using SchoolMedicalServer.Abstractions.Dtos.Notification;
 using SchoolMedicalServer.Abstractions.Dtos.Pagination;

--- a/SchoolMedicalServer.Infrastructure/Services/FileService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/FileService.cs
@@ -1,5 +1,4 @@
 ﻿using ClosedXML.Excel;
-using DocumentFormat.OpenXml.VariantTypes;
 using Microsoft.AspNetCore.Http;
 using SchoolMedicalServer.Abstractions.Entities;
 using SchoolMedicalServer.Abstractions.IRepositories;

--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckResultService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckResultService.cs
@@ -1,5 +1,4 @@
 ﻿using SchoolMedicalServer.Abstractions.Dtos.HealthCheck.Results;
-using SchoolMedicalServer.Abstractions.Dtos.HealthCheck.Rounds;
 using SchoolMedicalServer.Abstractions.Dtos.Notification;
 using SchoolMedicalServer.Abstractions.Dtos.Pagination;
 using SchoolMedicalServer.Abstractions.Entities;
@@ -158,9 +157,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
             }
             return new PaginationResponse<HealthCheckResultResponse>
             (
-                totalCount,
                 request!.PageIndex,
                 request.PageSize,
+                totalCount,
                 responses
             );
         }

--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
@@ -58,9 +58,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 responses.Add(await MapToDetailsResponse(round));
             }
             return new PaginationResponse<HealthCheckRoundResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
         }
@@ -170,9 +170,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 });
             }
             return new PaginationResponse<HealthCheckRoundStudentResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
         }
@@ -200,9 +200,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 });
             }
             return new PaginationResponse<HealthCheckRoundStudentResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
         }

--- a/SchoolMedicalServer.Infrastructure/Services/MedicalEventService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalEventService.cs
@@ -45,6 +45,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 var inventoryItem = await inventoryRepo.GetByIdAsync(item.ItemId);
                 if (inventoryItem == null) return null!;
                 inventoryItem.QuantityInStock -= item.RequestQuantity ?? 0;
+                inventoryItem.LastExportDate = DateTime.UtcNow;
                 if (inventoryItem.QuantityInStock == inventoryItem.MinimumStockLevel)
                 {
                     inventoryItem.Status = false;

--- a/SchoolMedicalServer.Infrastructure/Services/MedicalRequestService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalRequestService.cs
@@ -1,0 +1,45 @@
+﻿using SchoolMedicalServer.Abstractions.Dtos.MedicalEvent;
+using SchoolMedicalServer.Abstractions.Dtos.Pagination;
+using SchoolMedicalServer.Abstractions.IRepositories;
+using SchoolMedicalServer.Abstractions.IServices;
+
+namespace SchoolMedicalServer.Infrastructure.Services
+{
+    public class MedicalRequestService(IMedicalRequestRepository requestRepository, IUserRepository userRepository) : IMedicalRequestService
+    {
+        public async Task<PaginationResponse<MedicalRequestResponse>> GetMedicalRequestsAsync(PaginationRequest? pagination)
+        {
+            var total = await requestRepository.CountAsync();
+            var skip = (pagination!.PageIndex - 1) * pagination.PageSize;
+            var requests = await requestRepository.GetMedicalRequestsAsync(pagination.PageSize, skip, pagination.Search);
+
+            var nurseInfor = await userRepository.GetByIdAsync(requests.Select(r => r.Event!.StaffNurseId!).FirstOrDefault() ?? Guid.Empty);
+            var response = requests.Select(r => new MedicalRequestResponse
+            {
+                EventInfo = new EventInfo
+                {
+                    EventId = r.Event!.EventId,
+                },
+                MedicalInfo = new MedicalInfo
+                {
+                    ItemId = r.Item!.ItemId,
+                    ItemName = r.Item.ItemName,
+                    RequestId = r.RequestId,
+                    RequestQuantity = r.RequestQuantity,
+                    RequestDate = r.RequestDate
+                },
+                NurseInfo = new NurseInfo
+                {
+                    NurseId = nurseInfor!.UserId,
+                    FullName = nurseInfor!.FullName!,
+                },
+            }).ToList();
+            return new PaginationResponse<MedicalRequestResponse>(
+                pagination.PageIndex,
+                pagination.PageSize,
+                total,
+                response
+            );
+        }
+    }
+}

--- a/SchoolMedicalServer.Infrastructure/Services/NotificationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/NotificationService.cs
@@ -56,8 +56,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
             return new PaginationResponse<NotificationResponse>(
                    pagination!.PageIndex,
                    pagination.PageSize,
-                    totalCount,
-                    result
+                   totalCount,
+                   result
              );
         }
         public async Task<NotificationResponse> SendAppoimentNotificationToNurseAsync(NotificationRequest request)

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationResultService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationResultService.cs
@@ -1,8 +1,4 @@
-﻿using System.Linq;
-using Azure.Core;
-using Azure;
-using SchoolMedicalServer.Abstractions.Dtos.HealthCheck.Results;
-using SchoolMedicalServer.Abstractions.Dtos.Notification;
+﻿using SchoolMedicalServer.Abstractions.Dtos.Notification;
 using SchoolMedicalServer.Abstractions.Dtos.Pagination;
 using SchoolMedicalServer.Abstractions.Dtos.Vaccination.Results;
 using SchoolMedicalServer.Abstractions.Entities;
@@ -246,9 +242,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                                 .ToList();
             return new PaginationResponse<VaccinationResultParentResponse>
             (
-                totalCount,
                 pagination!.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
         }

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
@@ -3,7 +3,6 @@ using SchoolMedicalServer.Abstractions.Dtos.Vaccination.Rounds;
 using SchoolMedicalServer.Abstractions.Entities;
 using SchoolMedicalServer.Abstractions.IRepositories;
 using SchoolMedicalServer.Abstractions.IServices;
-using SchoolMedicalServer.Infrastructure.Repositories;
 
 namespace SchoolMedicalServer.Infrastructure.Services
 {
@@ -36,9 +35,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 });
             }
             return new PaginationResponse<VaccinationRoundStudentResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
         }
@@ -126,9 +125,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 response.Add(MapToRoundResponse(round, nurse!));
             }
             return new PaginationResponse<VaccinationRoundResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 response
             );
         }
@@ -194,9 +193,9 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 });
             }
             return new PaginationResponse<VaccinationRoundStudentResponse>(
-                totalCount,
                 pagination.PageIndex,
                 pagination.PageSize,
+                totalCount,
                 responses
             );
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `SchoolMedicalServer` project, focusing on medical request functionality, service improvements, and pagination fixes. The most significant changes include the addition of a new `MedicalRequestResponse` DTO, updates to the repository and service layers to support medical request pagination, and adjustments to service registration lifetimes for improved dependency management.

### Medical Request Enhancements:
* Added `MedicalRequestResponse` DTO in `SchoolMedicalServer.Abstractions/Dtos/MedicalEvent/MedicalRequestResponse.cs` to encapsulate medical request data, including event, nurse, and medical item information.
* Implemented `IMedicalRequestService` interface in `SchoolMedicalServer.Abstractions/IServices/IMedicalRequestService.cs` for handling paginated medical requests.
* Added `MedicalRequestService` implementation in `SchoolMedicalServer.Infrastructure/Services/MedicalRequestService.cs` to fetch paginated medical requests and map them to the `MedicalRequestResponse` DTO.
* Updated `IMedicalRequestRepository` to include methods for counting medical requests and fetching paginated results with optional search functionality in `SchoolMedicalServer.Abstractions/IRepositories/IMedicalRequestRepository.cs`.
* Added API endpoint in `MedicalRequestController` to retrieve paginated medical requests via `IMedicalRequestService` in `SchoolMedicalServer.Api/Controllers/MedicalEvent/MedicalRequestController.cs`.

### Service Improvements:
* Changed service lifetimes from `Transient` to `Scoped` for better dependency management in `SchoolMedicalServer.Api/Bootstrapping/ServiceServiceCollectionExtensions.cs`.
* Registered `IMedicalRequestService` in the service collection for dependency injection in `SchoolMedicalServer.Api/Bootstrapping/ServiceServiceCollectionExtensions.cs`.

### Pagination Fixes:
* Fixed missing `totalCount` parameter in pagination responses across multiple services, including `HealthCheckResultService`, `HealthCheckRoundService`, `VaccinationResultService`, and `VaccinationRoundService`. [[1]](diffhunk://#diff-917369ca68c0b79ea5b02454a1eae98bb673a408ce0c907dd38296cafdb30528L161-R162) [[2]](diffhunk://#diff-a5a1e4ec656da9acd643be02fff3d4515455b87fd27b64a4df1cf683395f65a3L61-R63) [[3]](diffhunk://#diff-a5a1e4ec656da9acd643be02fff3d4515455b87fd27b64a4df1cf683395f65a3L173-R175) [[4]](diffhunk://#diff-8e71094af73b0cef6c6501b1a16d7606521c6ac93e891c343fb3f50e477882bfL249-R247) [[5]](diffhunk://#diff-edde306d2803603363d7e08c18a83e022024412628d1a40c4b9fa9ddbc596af6L129-R130)

### Miscellaneous Updates:
* Added `LastExportDate` field update for inventory items in `MedicalEventService` when medical items are exported.
* Removed unused imports across various service files to clean up code. [[1]](diffhunk://#diff-a348fe953575787e46ad4acd781edeec6814e84c75941ef207bd39b6f61ea8ebL1) [[2]](diffhunk://#diff-32eb7a2f7cb99385e267eb45df7efb39095dc4edb345080e427fab5df1985d27L2) [[3]](diffhunk://#diff-917369ca68c0b79ea5b02454a1eae98bb673a408ce0c907dd38296cafdb30528L2) [[4]](diffhunk://#diff-8e71094af73b0cef6c6501b1a16d7606521c6ac93e891c343fb3f50e477882bfL1-R1) [[5]](diffhunk://#diff-edde306d2803603363d7e08c18a83e022024412628d1a40c4b9fa9ddbc596af6L6)- Removed unused `using` directives in several files for cleaner code.
- Introduced `CountAsync()` and `GetMedicalRequestsAsync()` methods in `IMedicalRequestRepository` and implemented them in `MedicalRequestRepository`.
- Updated service registrations in `ServiceServiceCollectionExtensions` from `AddTransient` to `AddScoped` and added `IMedicalRequestService`.
- Created `MedicalRequestController` to handle GET requests for medical requests with pagination.
- Added new DTO structure in `MedicalRequestResponse` to encapsulate response details.
- Updated `IMedicalRequestService` interface to include pagination method for medical requests.
- Ensured consistency in pagination response handling across health check and vaccination-related files.