### PR TITLE
Add vaccination observation retrieval functionality

### DIFF
--- a/SchoolMedicalServer.Abstractions/IServices/IVaccinationResultService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IVaccinationResultService.cs
@@ -10,6 +10,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
         Task<NotificationRequest> CreateVaccinationObservation(VaccinationObservationRequest request);
         Task<bool> CreateVaccinationResult(VaccinationResultRequest request);
         Task<bool?> GetHealthQualifiedVaccinationResult(Guid resultId);
+        Task<IEnumerable<VaccinationObservationInformationResponse>> GetVaccinationObservationsByRoundId(Guid roundId);
         Task<VaccinationResultResponse> GetVaccinationResult(Guid resultId);
         Task<PaginationResponse<VaccinationResultParentResponse>> GetVaccinationResultStudentAsync(PaginationRequest? pagination, Guid studentId);
         Task<bool?> IsVaccinationConfirmed(Guid resultId);

--- a/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationResultController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationResultController.cs
@@ -54,6 +54,18 @@ namespace SchoolMedicalServer.Api.Controllers.Vaccination
             return Ok(notification);
         }
 
+        [HttpGet("vaccination-rounds/{roundId}/vaccination-results/observations")]
+        [Authorize(Roles = "nurse")]
+        public async Task<IActionResult> GetVaccinationObservationsByRoundId(Guid roundId)
+        {
+            var observations = await service.GetVaccinationObservationsByRoundId(roundId);
+            if (observations == null)
+            {
+                return NotFound(new { Message = "No vaccination observations found for this round." });
+            }
+            return Ok(observations);
+        }
+
         [HttpGet("vaccination-results/{resultId}")]
         [Authorize(Roles = "admin, manager, nurse, parent")]
         public async Task<IActionResult> GetVaccinationResult(Guid resultId)

--- a/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationRoundController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationRoundController.cs
@@ -62,6 +62,7 @@ namespace SchoolMedicalServer.Api.Controllers.Vaccination
             return Ok(vaccinationRound);
         }
 
+
         [HttpGet("v2/nurses/{nurseId}/vaccination-rounds/{roundId}/students")]
         [Authorize(Roles = "nurse")]
         public async Task<IActionResult> GetStudentsByRoundIdForNurse(Guid roundId, Guid nurseId)

--- a/SchoolMedicalServer.Infrastructure/Repositories/VaccinationResultRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/VaccinationResultRepository.cs
@@ -133,6 +133,7 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
             return await _context.VaccinationResults
                 .Include(vr => vr.HealthProfile)
                 .ThenInclude(hp => hp!.Student)
+                .Include(vr => vr.VaccinationObservation)
                 .Where(vr => vr.RoundId == roundId)
                 .ToListAsync() ?? [];
         }

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationResultService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationResultService.cs
@@ -252,5 +252,39 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 responses
             );
         }
+
+        public async Task<IEnumerable<VaccinationObservationInformationResponse>> GetVaccinationObservationsByRoundId(Guid roundId)
+        {
+            var round = await roundRepository.GetVaccinationRoundByIdAsync(roundId);
+            if (round == null)
+            {
+                return null!;
+            }
+            var results = await resultRepository.GetByRoundIdAsync(roundId);
+            if (results == null || !results.Any())
+            {
+                return null!;
+            }
+            var observations = new List<VaccinationObservationInformationResponse>();
+            foreach (var result in results)
+            {
+                if (result.VaccinationObservation != null)
+                {
+                    observations.Add(new VaccinationObservationInformationResponse
+                    {
+                        ObservationStartTime = result.VaccinationObservation.ObservationStartTime,
+                        ObservationEndTime = result.VaccinationObservation.ObservationEndTime,
+                        ReactionStartTime = result.VaccinationObservation.ReactionStartTime,
+                        ImmediateReaction = result.VaccinationObservation.ImmediateReaction,
+                        Intervention = result.VaccinationObservation.Intervention,
+                        ReactionType = result.VaccinationObservation.ReactionType,
+                        SeverityLevel = result.VaccinationObservation.SeverityLevel,
+                        ObservedBy = result.VaccinationObservation.ObservedBy,
+                        Notes = result.VaccinationObservation.Notes
+                    });
+                }
+            }
+            return observations;
+        }
     }
 }


### PR DESCRIPTION
- Updated `IVaccinationResultService` to include `GetVaccinationObservationsByRoundId`.
- Added a new endpoint in `VaccinationResultController` for nurses to fetch vaccination observations by round ID.
- Introduced a new endpoint in `VaccinationRoundController` for nurses to retrieve students by vaccination round.
- Modified `VaccinationResultRepository` to include vaccination observations in results by round ID.
- Implemented logic in `VaccinationResultService` to handle retrieval of vaccination observations.