### PR TITLE
Update PageSize validation range in PaginationRequest

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Pagination/PaginationRequest.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Pagination/PaginationRequest.cs
@@ -4,7 +4,7 @@ namespace SchoolMedicalServer.Abstractions.Dtos.Pagination
 {
     public class PaginationRequest
     {
-        [Range(10, 40)]
+        [Range(3, 40)]
         public int PageSize { get; set; } = 10;
 
         [Range(1, 100)]


### PR DESCRIPTION
This pull request includes a small change to the `PaginationRequest` class in the `SchoolMedicalServer.Abstractions` namespace. The change updates the allowed range for the `PageSize` property, reducing the minimum value from 10 to 3.Modified the minimum value for the `PageSize` property from 10 to 3, allowing for smaller page sizes in pagination requests.