### PR TITLE
Add supplementary student count endpoints and services

### DIFF
--- a/SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IHealthCheckRoundService.cs
@@ -12,6 +12,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
         Task<PaginationResponse<HealthCheckRoundStudentResponse>> GetStudentsByHealthCheckRoundIdForManagerAsync(PaginationRequest? pagination, Guid roundId);
         Task<PaginationResponse<HealthCheckRoundStudentResponse>> GetStudentsByHealthCheckRoundIdForNurseAsync(PaginationRequest? pagination, Guid roundId, Guid nurseId);
         Task<IEnumerable<HealthCheckRoundStudentResponse>> GetStudentsByHealthCheckRoundIdForNurseAsync(Guid roundId, Guid nurseId);
+        Task<int> GetTotalSupplementaryTotalStudentsAsync(Guid scheduleId);
         Task<bool> UpdateHealthCheckRoundAsync(Guid roundId, HealthCheckRoundUpdateRequest request);
         Task<bool> UpdateHealthCheckRoundStatusAsync(Guid roundId, bool request);
     }

--- a/SchoolMedicalServer.Abstractions/IServices/IVaccinationRoundService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IVaccinationRoundService.cs
@@ -12,8 +12,9 @@ namespace SchoolMedicalServer.Abstractions.IServices
         Task<IEnumerable<VaccinationRoundResponse>> GetVaccinationRoundsByScheduleIdAsync(Guid scheduleId);
         Task<PaginationResponse<VaccinationRoundResponse>> GetVaccinationRoundsByNurseIdAsync(Guid nurseId, PaginationRequest? pagination);
         Task<bool> UpdateVaccinationRoundStatusAsync(Guid roundId, bool request);
-        Task<bool> CreateVaccinationRoundByScheduleIdAsync(VaccinationRoundRequest request);
+        Task<bool> CreateVaccinationRegularRoundByScheduleIdAsync(VaccinationRoundRequest request);
         Task<bool> UpdateVaccinationRoundAsync(Guid roundId, VaccinationRoundUpdateRequest request);
         Task<IEnumerable<VaccinationRoundStudentResponse>> GetStudentsByVacciantionRoundIdForNurseAsync(Guid roundId, Guid nurseId);
+        Task<int> GetTotalSupplementaryTotalStudentsAsync(Guid scheduleId);
     }
 }

--- a/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.cs
+++ b/SchoolMedicalServer.Api/Controllers/HealthCheck/HealthCheckRoundController.cs
@@ -20,6 +20,19 @@
             return Ok(new { Message = "Health check round updated successfully." });
         }
 
+        [HttpGet("schedules/{scheduleId}/health-check-rounds/supplementary/total-students")]
+        [Authorize(Roles = "admin, manager")]
+        public async Task<IActionResult> GetTotalSupplementaryTotalStudents(Guid scheduleId)
+        {
+            if (scheduleId == Guid.Empty)
+            {
+                return BadRequest(new { Message = "Invalid request data." });
+            }
+            var result = await service.GetTotalSupplementaryTotalStudentsAsync(scheduleId);
+            return Ok(new { SupplementStudents = result });
+        }
+
+
         [HttpGet("managers/health-check-rounds/{roundId}/students")]
         [Authorize(Roles = "admin, manager")]
         public async Task<IActionResult> GetStudentsByHealthCheckRoundId([FromQuery] PaginationRequest? pagination, Guid roundId)

--- a/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationRoundController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Vaccination/VaccinationRoundController.cs
@@ -12,12 +12,24 @@
             {
                 return BadRequest(new { Message = "Invalid request data." });
             }
-            var result = await service.CreateVaccinationRoundByScheduleIdAsync(request);
+            var result = await service.CreateVaccinationRegularRoundByScheduleIdAsync(request);
             if (!result)
             {
                 return NotFound(new { Message = "Vaccination round not found or update failed." });
             }
             return Ok(new { Message = "Vaccination round updated successfully." });
+        }
+
+        [HttpGet("schedules/{scheduleId}/vaccination-rounds/supplementary/total-students")]
+        [Authorize(Roles = "admin, manager")]
+        public async Task<IActionResult> GetTotalSupplementaryTotalStudents(Guid scheduleId)
+        {
+            if (scheduleId == Guid.Empty)
+            {
+                return BadRequest(new { Message = "Invalid request data." });
+            }
+            var result = await service.GetTotalSupplementaryTotalStudentsAsync(scheduleId);
+            return Ok(new { SupplementStudents = result });
         }
 
         [HttpGet("managers/vaccination-rounds/{roundId}/students")]


### PR DESCRIPTION
- Updated `IHealthCheckRoundService` and `IVaccinationRoundService` to include `GetTotalSupplementaryTotalStudentsAsync`.
- Renamed `CreateVaccinationRoundByScheduleIdAsync` to `CreateVaccinationRegularRoundByScheduleIdAsync`.
- Added new endpoints in `HealthCheckRoundController` and `VaccinationRoundController` for retrieving supplementary student counts.
- Implemented logic in `HealthCheckRoundService` and `VaccinationRoundService` to calculate supplementary student totals.
- Enhances data handling and reporting capabilities for health check and vaccination rounds.