### PR TITLE
Remove supplementary student check in round services

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs
@@ -28,15 +28,6 @@ namespace SchoolMedicalServer.Infrastructure.Services
             if (schedule.Rounds.Any(r => r.TargetGrade!.Equals(request.TargetGrade!)))
                 return false;
 
-            if (request.TargetGrade!.Contains("supplement"))
-            {
-                var supplementStudents = await GetTotalSupplementaryTotalStudentsAsync(request.ScheduleId!.Value);
-                if (supplementStudents == 0)
-                {
-                    return false;
-                }
-            }
-
             var round = new HealthCheckRound
             {
                 RoundId = Guid.NewGuid(),

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs
@@ -207,15 +207,6 @@ namespace SchoolMedicalServer.Infrastructure.Services
             if (schedule.Rounds.Any(r => r.TargetGrade!.Equals(request.TargetGrade!)))
                 return false;
 
-            if (request.TargetGrade!.Contains("supplement"))
-            {
-                var supplementaryTotalStudents = await GetTotalSupplementaryTotalStudentsAsync(request.ScheduleId.Value);
-                if (supplementaryTotalStudents == 0)
-                {
-                    return false;
-                }
-            }
-
             var round = new VaccinationRound
             {
                 RoundId = Guid.NewGuid(),


### PR DESCRIPTION
This pull request simplifies the logic for creating health check and vaccination rounds by removing checks related to supplementary students. These changes streamline the code and reduce unnecessary conditional logic.

### Simplification of round creation logic:

* [`SchoolMedicalServer.Infrastructure/Services/HealthCheckRoundService.cs`](diffhunk://#diff-a5a1e4ec656da9acd643be02fff3d4515455b87fd27b64a4df1cf683395f65a3L31-L39): Removed the conditional check for supplementary students in the `CreateHealthCheckRoundByScheduleIdAsync` method. This eliminates the dependency on the `GetTotalSupplementaryTotalStudentsAsync` method and simplifies the round creation process.
* [`SchoolMedicalServer.Infrastructure/Services/VaccinationRoundService.cs`](diffhunk://#diff-edde306d2803603363d7e08c18a83e022024412628d1a40c4b9fa9ddbc596af6L210-L218): Removed the conditional check for supplementary students in the `CreateVaccinationRegularRoundByScheduleIdAsync` method, similarly simplifying the logic and removing the call to `GetTotalSupplementaryTotalStudentsAsync`.Eliminate the conditional block that checks for "supplement" in `TargetGrade` in both `HealthCheckRoundService.cs` and `VaccinationRoundService.cs`. This change simplifies the logic by removing the check for supplementary students before creating a new round.