### PR TITLE
Update Excel export for health observations

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/ExportFileService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/ExportFileService.cs
@@ -210,11 +210,22 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 worksheet.Cell(1, 10).Value = "VaccinatedDate";
                 worksheet.Cell(1, 11).Value = "VaccinatedTime";
                 worksheet.Cell(1, 12).Value = "InjectionSite";
-                worksheet.Cell(1, 13).Value = "ObservationNotes";
-                worksheet.Cell(1, 14).Value = "Notes";
+                worksheet.Cell(1, 13).Value = "Notes";
+                worksheet.Cell(1, 14).Value = "ObservationNotes";
 
-          
-                var titleRange = worksheet.Range(1, 1, 1, 14);
+
+                worksheet.Cell(1, 15).Value = "ReactionStartTime";
+                worksheet.Cell(1, 16).Value = "ReactionType";
+                worksheet.Cell(1, 17).Value = "SeverityLevel";
+                worksheet.Cell(1, 18).Value = "ImmediateReaction";
+              
+                worksheet.Cell(1, 19).Value = "Intervention";
+                worksheet.Cell(1, 20).Value = "ObservationEndTime";
+                worksheet.Cell(1, 21).Value = "ObservationStartTime";
+                worksheet.Cell(1, 22).Value = "ObservedBy";
+
+
+                var titleRange = worksheet.Range(1, 1, 1, 25);
                 titleRange.Style.Font.Bold = true;
                 titleRange.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
                 titleRange.Style.Font.FontSize = 12;
@@ -239,7 +250,6 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     worksheet.Cell(row, 4).Value = student?.Gender ?? "";
                     worksheet.Cell(row, 5).Value = student?.Grade ?? "";
                     worksheet.Cell(row, 6).Value = student?.ParentPhoneNumber ?? "";
-
                     worksheet.Cell(row, 7).Value = result.ParentConfirmed.HasValue
                         ? (result.ParentConfirmed.Value ? "Confirmed" : "Declined")
                         : "Pending";
@@ -254,13 +264,23 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     worksheet.Cell(row, 12).Value = !string.IsNullOrEmpty(result.InjectionSite)
                         ? result.InjectionSite
                         : "Not specified";
-
-                    worksheet.Cell(row, 13).Value = observation != null && !string.IsNullOrEmpty(observation.Notes)
-                        ? observation.Notes
-                        : "No observations recorded";
-                    worksheet.Cell(row, 14).Value = !string.IsNullOrEmpty(result.Notes)
+                    worksheet.Cell(row, 13).Value = !string.IsNullOrEmpty(result.Notes)
                         ? result.Notes
                         : "No notes";
+                    worksheet.Cell(row, 14).Value = observation?.Notes ?? "No observation notes";
+
+        
+
+                    worksheet.Cell(row, 15).Value = observation?.ReactionStartTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A";
+                    worksheet.Cell(row, 16).Value = observation?.ReactionType ?? "normal";
+                    worksheet.Cell(row, 17).Value = observation?.SeverityLevel ?? "normal";
+                    worksheet.Cell(row, 18).Value = observation?.ImmediateReaction ?? "no";
+        
+                    worksheet.Cell(row, 19).Value = observation?.Intervention ?? "no";
+                    worksheet.Cell(row, 20).Value = observation?.ObservationEndTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A";
+                    worksheet.Cell(row, 21).Value = observation?.ObservationStartTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A";
+                    worksheet.Cell(row, 22).Value = observation?.ObservedBy ?? "N/A";
+
 
                     row++;
                 }


### PR DESCRIPTION
This pull request updates the `ExportVaccinationResultsExcelFileAsync` method in the `ExportFileService` class to enhance the exported Excel file with additional fields related to vaccination observations and reactions. It also refactors the order of existing columns and simplifies conditional logic for populating cell values.

### Enhancements to Excel Export:

* Added new columns to the Excel file for detailed vaccination observation data, including `ReactionStartTime`, `ReactionType`, `SeverityLevel`, `ImmediateReaction`, `Intervention`, `ObservationEndTime`, `ObservationStartTime`, and `ObservedBy`. These columns provide more comprehensive information about post-vaccination reactions. [[1]](diffhunk://#diff-8a5a0e9f275aa147394f857237e5cc1badd2c25c18000c1b8456fff92cb1d866L213-R228) [[2]](diffhunk://#diff-8a5a0e9f275aa147394f857237e5cc1badd2c25c18000c1b8456fff92cb1d866L257-R283)
* Updated the range for the title row to accommodate the newly added columns, ensuring proper styling for the expanded set of headers.

### Refactoring and Simplification:

* Swapped the order of the `Notes` and `ObservationNotes` columns in the header row for better organization and consistency.
* Simplified conditional logic for populating cell values, using the null-coalescing operator (`??`) to handle cases where observation data may be missing.

### Code Cleanup:

* Removed unnecessary blank lines and streamlined the layout of the method for improved readability.Rearranged and added new columns in the Excel worksheet headers, including "ReactionStartTime," "ReactionType," "SeverityLevel," "ImmediateReaction," "Intervention," "ObservationEndTime," "ObservationStartTime," and "ObservedBy." Adjusted the title range accordingly.

Modified data population logic for "Notes" and "ObservationNotes" fields to pull from the appropriate objects, enhancing the detail of health observation data.