### PR TITLE
Add HealthCheckResult to NotificationTypes enum

### DIFF
--- a/SchoolMedicalServer.Abstractions/Entities/Notification.cs
+++ b/SchoolMedicalServer.Abstractions/Entities/Notification.cs
@@ -24,5 +24,6 @@ public enum NotificationTypes
     Vaccination = 5,
     GeneralNotification = 6,
     VaccinationObservation = 7,
-    VaccinationResult = 8
+    VaccinationResult = 8,
+    HealthCheckResult = 9
 }

--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs
@@ -96,7 +96,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 Content = $"The health check result for your child {result.HealthProfile!.Student!.FullName} is now available.",
                 SendDate = DateTime.UtcNow,
                 IsRead = false,
-                Type = NotificationTypes.HealthCheckUp,
+                Type = NotificationTypes.HealthCheckResult,
                 SourceId = result.ResultId
             };
             await notificationRepository.AddAsync(notification);


### PR DESCRIPTION
This pull request introduces a new notification type, `HealthCheckResult`, to the `NotificationTypes` enum and updates the relevant code to use this new type. These changes ensure that health check results are properly categorized and handled in the notification system.

### Notification system changes:

* [`SchoolMedicalServer.Abstractions/Entities/Notification.cs`](diffhunk://#diff-558e4e965ec93aae922737f48b76621aefd7557b1d7ef7e3b45cadc70b79c3f4L27-R28): Added a new `HealthCheckResult` notification type to the `NotificationTypes` enum.
* [`SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs`](diffhunk://#diff-45e7058a12e98303326058cf6e1c777e4d5386535f615ab149fe01c05aabff36L99-R99): Updated the `SendHealthCheckResultNotificationToParent` method to use the new `HealthCheckResult` type instead of the previously used `HealthCheckUp` type.Updated the `NotificationTypes` enum in `Notification.cs` to include a new value, `HealthCheckResult` (9). Changed the notification type in `HealthCheckNotificationService.cs` from `HealthCheckUp` to `HealthCheckResult` to reflect this addition.