### PR TITLE
Update ParentConfirmed to null in health check services

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckScheduleService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckScheduleService.cs
@@ -99,7 +99,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     ResultId = Guid.NewGuid(),
                     HealthProfileId = hp!.HealthProfileId!,
                     RoundId = round.RoundId,
-                    ParentConfirmed = true,
+                    ParentConfirmed = null,
                     Status = "Pending",
                     RecordedId = round.NurseId,
                     CreatedAt = DateTime.UtcNow

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs
@@ -100,7 +100,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     VaccinationResultId = Guid.NewGuid(),
                     HealthProfileId = healthProfile.HealthProfileId,
                     RoundId = round.RoundId,
-                    ParentConfirmed = true,
+                    ParentConfirmed = null,
                     HealthQualified = true,
                     Vaccinated = false,
                     RecorderId = round.NurseId,


### PR DESCRIPTION
This pull request modifies the `ParentConfirmed` property in two services to set its value to `null` instead of `true`. These changes ensure consistency in how the `ParentConfirmed` field is initialized during the processing of health check and vaccination rounds.

Changes to `ParentConfirmed` initialization:

* [`SchoolMedicalServer.Infrastructure/Services/HealthCheckScheduleService.cs`](diffhunk://#diff-6c86a4953625195738180a582172d64bd746ef396bf1c31c0950833fc63c4498L102-R102): Updated the `ParentConfirmed` field in `ProcessSupplementRound` to initialize as `null` instead of `true`.
* [`SchoolMedicalServer.Infrastructure/Services/VaccinationScheduleService.cs`](diffhunk://#diff-d76468debc38775f79603b629119a49add0655d77b2c35d723d68456889aea0cL103-R103): Updated the `ParentConfirmed` field in `ProcessSupplementRound` to initialize as `null` instead of `true`.Modified the `ParentConfirmed` property in `HealthCheckResult` and `VaccinationResult` classes to be `null` instead of `true`. This change reflects that the confirmation status from the parent is now considered unknown or not applicable.