### PR TITLE
Improve appointment notification messages and status handling

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/AppointmentNotificationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AppointmentNotificationService.cs
@@ -47,16 +47,27 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
             var receiver = await notificationHelper.GetReceiverInformationAsync(request);
             var sender = await notificationHelper.GetSenderInformationAsync(request);
+            var body = "";
+            if (appointment.ConfirmationStatus == true && appointment.CompletionStatus == null)
+            {
+                body = $"Your appointment with {sender!.UserName} is confirmed for {appointment.AppointmentDate?.ToString("d")} from {appointment.AppointmentStartTime?.ToString()} to {appointment.AppointmentEndTime?.ToString()}.";
+            }
+            else if (appointment.CompletionStatus == true)
+            {
+                body = $"Your appointment with {sender!.UserName} is completed for {appointment.AppointmentDate?.ToString("d")} from {appointment.AppointmentStartTime?.ToString()} to {appointment.AppointmentEndTime?.ToString()}.";
+            }
+            else
+            {
+                body = $"Your appointment with {sender!.UserName} is not completed for {appointment.AppointmentDate?.ToString("d")} from {appointment.AppointmentStartTime?.ToString()} to {appointment.AppointmentEndTime?.ToString()}.";
+            }
 
             var notification = new Notification
             {
                 NotificationId = Guid.NewGuid(),
                 SenderId = sender!.UserId,
                 UserId = receiver!.UserId,
-                Title = appointment.CompletionStatus == false ? "Appointment Confirmation" : "Appointment Completion",
-                Content = appointment.CompletionStatus == true
-                            ? $"Your appointment with {sender!.UserName} is completed for {appointment.AppointmentDate?.ToString("d")} from {appointment.AppointmentStartTime?.ToString()} to {appointment.AppointmentEndTime?.ToString()}."
-                            : $"Your appointment with {sender!.UserName} is confirmed for {appointment.AppointmentDate?.ToString("d")} from {appointment.AppointmentStartTime?.ToString()} to {appointment.AppointmentEndTime?.ToString()}.",
+                Title = appointment.CompletionStatus == null ? "Appointment Confirmation" : "Appointment Completion",
+                Content = body,
                 SendDate = DateTime.UtcNow,
                 IsRead = false,
                 Type = NotificationTypes.Appointment,

--- a/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
@@ -91,7 +91,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 AppointmentEndTime = request.AppointmentEndTime,
                 AppointmentReason = request.AppointmentReason,
                 ConfirmationStatus = false,
-                CompletionStatus = false
+                CompletionStatus = null
             };
             await appointmentRepository.AddAsync(appointment);
             await baseRepository.SaveChangesAsync();


### PR DESCRIPTION
This pull request introduces changes to improve the handling of appointment notifications and updates the `CompletionStatus` field to better reflect appointment states. The most important updates include refactoring the notification message logic for clarity and changing the `CompletionStatus` field from a boolean to a nullable type.

### Improvements to notification logic:

* [`SchoolMedicalServer.Infrastructure/Services/AppointmentNotificationService.cs`](diffhunk://#diff-23c2f34b0f4195db958d819586a138f63c83092480515c7cd6ec669b2ad6b002R50-R70): Refactored the notification message logic in `SendAppointmentNotificationToParentAsync` to use a `body` variable for constructing the notification content based on the appointment's `ConfirmationStatus` and `CompletionStatus`. This improves readability and maintainability.

### Changes to appointment state handling:

* [`SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs`](diffhunk://#diff-a348fe953575787e46ad4acd781edeec6814e84c75941ef207bd39b6f61ea8ebL94-R94): Updated the `CompletionStatus` field in `RegisterAppointment` from a boolean (`false`) to a nullable type (`null`) to better represent the state of an appointment that has not yet been completed.Updated notification content in `AppointmentNotificationService.cs` to provide clearer information based on appointment completion status. Changed `CompletionStatus` in `AppointmentService.cs` from a boolean to a nullable type for better flexibility in representing appointment states.

Enhance appointment notifications and status handling

Updated `AppointmentNotificationService.cs` to construct a dynamic message for notifications based on appointment confirmation and completion status. The notification's `Title` and `Content` now utilize a new `body` variable for improved clarity.

Modified `AppointmentService.cs` to set `CompletionStatus` to `null` when creating new appointments, allowing for better distinction between uncompleted and explicitly not completed appointments.