### PR TITLE
Add NurseNotes property to MedicalRegistrationResponse

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/MedicalRegistration/MedicalRegistrationResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/MedicalRegistration/MedicalRegistrationResponse.cs
@@ -21,6 +21,7 @@ namespace SchoolMedicalServer.Abstractions.Dtos.MedicalRegistration
         public DateOnly? DateSubmitted { get; set; }
         public string? PictureUrl { get; set; }
         public bool? Status { get; set; }
+        public string? NurseNotes { get; set; }
     }
 
     public class MedicalRegistrationDetailsResponse

--- a/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
@@ -305,7 +305,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
                     Notes = medicalRegistration.Notes,
                     ParentConsent = medicalRegistration.ParentalConsent ?? false,
                     DateSubmitted = medicalRegistration.DateSubmitted,
-                    Status = medicalRegistration.Status
+                    Status = medicalRegistration.Status,
+                    NurseNotes = medicalRegistration.NurseNotes
                 },
                 MedicalRegistrationDetails = details,
                 NurseApproved = nurseApprovedResponse,


### PR DESCRIPTION
This pull request introduces a new property, `NurseNotes`, to the medical registration response DTO and updates the corresponding service to include this property in its response. These changes enhance the functionality by allowing nurse-specific notes to be captured and returned in the medical registration process.

### Enhancements to Medical Registration Response:

* [`SchoolMedicalServer.Abstractions/Dtos/MedicalRegistration/MedicalRegistrationResponse.cs`](diffhunk://#diff-b4b2bf421a6c4e9b1e7b20dca077c9922d11c5489cd52f46b93f60fde118c84aR24): Added a new property, `NurseNotes`, to the `MedicalRegistrationResponseDto` class to store notes from nurses.

### Updates to Service Logic:

* [`SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs`](diffhunk://#diff-508ba944594acb97a852fabef587e9a6143b494de1d328af365262f0f639362fL308-R309): Updated the `GetResponse` method to populate the newly added `NurseNotes` property from the `MedicalRegistration` entity.This commit introduces a new `NurseNotes` property of type `string?` to the `MedicalRegistrationResponse` class, allowing for additional notes from the nurse. The `NurseNotes` property is also included in the response object constructed in `MedicalRegistrationService.cs`, ensuring it is part of the medical registration response alongside existing properties like `Status`, `PictureUrl`, and `Notes`.