### PR TITLE
Add methods to retrieve cancelled appointments and registrations

### DIFF
--- a/SchoolMedicalServer.Abstractions/IRepositories/IAppointmentRepository.cs
+++ b/SchoolMedicalServer.Abstractions/IRepositories/IAppointmentRepository.cs
@@ -28,7 +28,6 @@ namespace SchoolMedicalServer.Abstractions.IRepositories
         void Update(Appointment appointment);
         Task<Appointment?> GetByIdWithStudentAsync(Guid appointmentId);
         Task<IEnumerable<Appointment>> GetAllAppointment();
-
-
+        Task<IEnumerable<Appointment>> GetByUserIdAsync(Guid userId);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IRepositories/IMedicalRegistrationRepository.cs
+++ b/SchoolMedicalServer.Abstractions/IRepositories/IMedicalRegistrationRepository.cs
@@ -13,6 +13,6 @@ namespace SchoolMedicalServer.Abstractions.IRepositories
         void Update(MedicalRegistration registration);
         Task<MedicalRegistration?> GetApprovedByIdWithStudentAsync(Guid registrationId);
         Task<IEnumerable<MedicalRegistration>> GetAllMedicalRegistration();
-
+        Task<IEnumerable<MedicalRegistration>> GetByUserIdAsync(Guid userId);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IServices/IAppointmentService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IAppointmentService.cs
@@ -17,5 +17,6 @@ namespace SchoolMedicalServer.Abstractions.IServices
         Task<PaginationResponse<AppointmentResponse>> GetUserAppointments(Guid userId, PaginationRequest? paginationRequest);
         Task<NotificationRequest> ApproveAppointment(Guid appointmentId, AppoinmentNurseApprovedRequest request);
         Task<bool> HasBookedAppointment(Guid userId);
+        Task<int> GetUserCancelAppointmentsInMonth(Guid userId);
     }
 }

--- a/SchoolMedicalServer.Abstractions/IServices/IMedicalRegistrationService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IMedicalRegistrationService.cs
@@ -13,6 +13,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
 
         Task<MedicalRegistrationResponse?> GetMedicalRegistrationAsync(Guid medicalRegistrationId);
         Task<PaginationResponse<MedicalRegistrationResponse?>> GetMedicalRegistrationsAsync(PaginationRequest? paginationRequest, Guid nurseId); //paginantion
+        Task<int> GetUserCancelMedicalRegistrationsInMonthAsync(Guid userId);
         Task<PaginationResponse<MedicalRegistrationResponse?>> GetUserMedicalRegistrationsAsync(PaginationRequest? paginationRequest, Guid userId); //paginantion
     }
 }

--- a/SchoolMedicalServer.Api/Controllers/Appointment/ParentAppointmentController.cs
+++ b/SchoolMedicalServer.Api/Controllers/Appointment/ParentAppointmentController.cs
@@ -64,5 +64,17 @@
 
             return Ok(appointment);
         }
+
+        [HttpGet("parents/{userId}/appointments/total-cancel")]
+        [Authorize(Roles = "parent")]
+        public async Task<IActionResult> GetTotalCancelledAppointments(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                return BadRequest("User ID cannot be empty.");
+            }
+            var totalCancelledInMonth = await service.GetUserCancelAppointmentsInMonth(userId);
+            return Ok(new { TotalCancelled = totalCancelledInMonth });
+        }
     }
 }

--- a/SchoolMedicalServer.Api/Controllers/MedicalRegistration/ParentMedicalRegistrationController.cs
+++ b/SchoolMedicalServer.Api/Controllers/MedicalRegistration/ParentMedicalRegistrationController.cs
@@ -47,5 +47,18 @@
             }
             return StatusCode(200, registrations);
         }
+
+        [HttpGet("parents/{userId}/medical-registrations/total-cancel")]
+        [Authorize(Roles = "parent")]
+        public async Task<IActionResult> GetTotalCancelledMedicalRegistrations(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                return BadRequest("Invalid user ID.");
+            }
+            var totalCancelledInMonth = await service.GetUserCancelMedicalRegistrationsInMonthAsync(userId);
+
+            return Ok(new { TotalCancelled = totalCancelledInMonth });
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Repositories/AppointmentRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/AppointmentRepository.cs
@@ -128,5 +128,15 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<Appointment>> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.Appointments
+                .Where(a => a.UserId == userId)
+                .Include(a => a.Student)
+                .Include(a => a.User)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Repositories/MedicalRegistrationRepository.cs
+++ b/SchoolMedicalServer.Infrastructure/Repositories/MedicalRegistrationRepository.cs
@@ -54,5 +54,16 @@ namespace SchoolMedicalServer.Infrastructure.Repositories
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<MedicalRegistration>> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.MedicalRegistrations
+                .Where(r => r.UserId == userId)
+                .Include(r => r.Student)
+                .Include(r => r.User)
+                .Include(r => r.Details)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs
@@ -283,5 +283,20 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
             return hasAppointment;
         }
+
+        public async Task<int> GetUserCancelAppointmentsInMonth(Guid userId)
+        {
+            var appointments = await appointmentRepository.GetByUserIdAsync(userId);
+            var firstDateOfMonth = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+            var lastDateOfMonth = firstDateOfMonth.AddMonths(1).AddDays(-1);
+            if (appointments == null || !appointments.Any())
+            {
+                return 0;
+            }
+            var cancelledAppointments = appointments
+                .Where(a => a.UserId == userId && a.CompletionStatus == false && a.AppointmentDate >= firstDateOfMonth && a.AppointmentDate <= lastDateOfMonth)
+                .Count();
+            return cancelledAppointments;
+        }
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs
@@ -316,5 +316,20 @@ namespace SchoolMedicalServer.Infrastructure.Services
 
             return response;
         }
+
+        public async Task<int> GetUserCancelMedicalRegistrationsInMonthAsync(Guid userId)
+        {
+            var registrations = await medicalRegistrationRepository.GetByUserIdAsync(userId);
+            if (registrations == null || !registrations.Any())
+            {
+                return 0;
+            }
+            var firstDateOfMonth = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+            var lastDateOfMonth = firstDateOfMonth.AddMonths(1).AddDays(-1);
+            var cancelledRegistrations = registrations
+                .Where(r => r.Status == false && r.DateSubmitted >= firstDateOfMonth && r.DateSubmitted <= lastDateOfMonth)
+                .Count();
+            return cancelledRegistrations;
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces new methods to retrieve and calculate user-specific data for appointments and medical registrations, focusing on cancellations within the current month. It updates repository interfaces, service interfaces, and their respective implementations, as well as adds new API endpoints for these functionalities.

### Repository Changes:
* Added `GetByUserIdAsync(Guid userId)` to `IAppointmentRepository` and `IMedicalRegistrationRepository` interfaces for retrieving user-specific appointments and medical registrations. (`SchoolMedicalServer.Abstractions/IRepositories/IAppointmentRepository.cs` - [[1]](diffhunk://#diff-46c3ef9c04ce0d5a25f12d72a9bee1bf55e6f7f033b1b614932920301e7a92feL31-R31) `SchoolMedicalServer.Abstractions/IRepositories/IMedicalRegistrationRepository.cs` - [[2]](diffhunk://#diff-77f1345bbaf82309fe0a23c886668e207e27c9765d89b3c9558e83767dec619fL16-R16)
* Implemented `GetByUserIdAsync` in `AppointmentRepository` and `MedicalRegistrationRepository` to fetch user-specific data with related entities. (`SchoolMedicalServer.Infrastructure/Repositories/AppointmentRepository.cs` - [[1]](diffhunk://#diff-576827054b7865a6ae59988749adf451229a2e01a8d0e96e86783352800cf54aR131-R140) `SchoolMedicalServer.Infrastructure/Repositories/MedicalRegistrationRepository.cs` - [[2]](diffhunk://#diff-33afe89d9314059717b8f636ad23421720ad98a8c07bc6fe77583dfc956b74b6R57-R67)

### Service Changes:
* Added `GetUserCancelAppointmentsInMonth(Guid userId)` and `GetUserCancelMedicalRegistrationsInMonthAsync(Guid userId)` methods to `IAppointmentService` and `IMedicalRegistrationService` interfaces. (`SchoolMedicalServer.Abstractions/IServices/IAppointmentService.cs` - [[1]](diffhunk://#diff-bfb910fac4297ad3ecc68838b4bec0f2f81d5815ea3b2d71560a27184dad082aR20) `SchoolMedicalServer.Abstractions/IServices/IMedicalRegistrationService.cs` - [[2]](diffhunk://#diff-554a822c09945df9f52e4b798a38bce21a6c46364c8970154cda0963eef26f61R16)
* Implemented the above methods in `AppointmentService` and `MedicalRegistrationService` to calculate cancellations within the current month. (`SchoolMedicalServer.Infrastructure/Services/AppointmentService.cs` - [[1]](diffhunk://#diff-a348fe953575787e46ad4acd781edeec6814e84c75941ef207bd39b6f61ea8ebR286-R300) `SchoolMedicalServer.Infrastructure/Services/MedicalRegistrationService.cs` - [[2]](diffhunk://#diff-508ba944594acb97a852fabef587e9a6143b494de1d328af365262f0f639362fR319-R333)

### API Changes:
* Added `GetTotalCancelledAppointments` and `GetTotalCancelledMedicalRegistrations` endpoints to allow parents to retrieve the total number of cancellations in the current month for appointments and medical registrations. (`SchoolMedicalServer.Api/Controllers/Appointment/ParentAppointmentController.cs` - [[1]](diffhunk://#diff-a73f70efd078c272a3ac46c00f4ffca1219e1b80d4a0248dcea75b0762725c94R67-R78) `SchoolMedicalServer.Api/Controllers/MedicalRegistration/ParentMedicalRegistrationController.cs` - [[2]](diffhunk://#diff-fd54aec3137f6b2c593b71d614b7908481011cc4bfe23be6218ef5cbcc9f57d5R50-R62)This commit introduces new functionality to fetch cancelled appointments and medical registrations for a specific user within a month.

- Added `GetByUserIdAsync(Guid userId)` methods in `IAppointmentRepository` and `IMedicalRegistrationRepository`.
- Introduced `GetUserCancelAppointmentsInMonth(Guid userId)` and `GetUserCancelMedicalRegistrationsInMonthAsync(Guid userId)` in their respective service interfaces.
- Implemented new HTTP GET endpoints in `ParentAppointmentController` and `ParentMedicalRegistrationController` for parents to access total cancelled records.
- Updated repository and service implementations to filter and count cancelled records based on user ID and the current month's date range.