### PR TITLE
Add health declaration existence check for parents

### DIFF
--- a/SchoolMedicalServer.Abstractions/IServices/IHealthProfileDeclarationService.cs
+++ b/SchoolMedicalServer.Abstractions/IServices/IHealthProfileDeclarationService.cs
@@ -6,6 +6,7 @@ namespace SchoolMedicalServer.Abstractions.IServices
     {
         Task<bool> CreateHealthDeclarationAsync(HealthProfileDeclarationRequest request);
         Task<HealthProfileDeclarationResponse?> GetHealthDeclarationAsync(Guid studentId);
+        Task<int> IsHealthDeclarationExistAsync(Guid parentId);
         Task<bool> UpdateHealthDeclarationAsync(HealthProfileDeclarationRequest request);
     }
 }

--- a/SchoolMedicalServer.Api/Controllers/HealthDeclaration/HealthDeclarationController.cs
+++ b/SchoolMedicalServer.Api/Controllers/HealthDeclaration/HealthDeclarationController.cs
@@ -5,6 +5,19 @@ namespace SchoolMedicalServer.Api.Controllers.HealthDeclaration
     public class HealthDeclarationController(IHealthProfileDeclarationService service) : ControllerBase
     {
 
+        [HttpGet("parents/{parentId}/students/total-health-declarations")]
+        [Authorize(Roles = "parent")]
+        public async Task<IActionResult> IsHealthDeclarationExist(Guid parentId)
+        {
+            if (parentId == Guid.Empty)
+            {
+                return BadRequest("Parent ID cannot be empty.");
+            }
+            var response = await service.IsHealthDeclarationExistAsync(parentId);
+
+            return Ok(response);
+        }
+
         [HttpGet("students/{studentId}/health-declarations")]
         [Authorize(Roles = "parent, nurse")]
         public async Task<IActionResult> GetHealthProfileDeclaration(Guid studentId)

--- a/SchoolMedicalServer.Infrastructure/Services/HealthProfileDeclarationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthProfileDeclarationService.cs
@@ -96,6 +96,14 @@ namespace SchoolMedicalServer.Infrastructure.Services
             return response;
         }
 
+        public async Task<int> IsHealthDeclarationExistAsync(Guid parentId)
+        {
+            var healthProfiles = await healthProfileRepository.GetAllAsync();
+            var studentIsNotDeclared = healthProfiles.Where(h => h.Student?.UserId == parentId && h.DeclarationDate == null)
+                .Select(h => h.StudentId).ToList();
+            return studentIsNotDeclared.Count;
+        }
+
         public async Task<bool> UpdateHealthDeclarationAsync(HealthProfileDeclarationRequest request)
         {
             var studentId = request.HealthDeclaration.StudentId;


### PR DESCRIPTION
- Updated `IHealthProfileDeclarationService` to include `IsHealthDeclarationExistAsync(Guid parentId)` method for checking health declarations.

- Added new endpoint in `HealthDeclarationController` to handle GET requests at `api/parents/{parentId}/students/total-health-declarations`, returning the count of health declarations for a given parent.

- Implemented the logic in `HealthProfileDeclarationService` to filter health profiles and count those without a declaration date for the specified parent.