### PR TITLE
Add ParentAccountCreated property to StudentInformationResponse

### DIFF
--- a/SchoolMedicalServer.Abstractions/Dtos/Student/StudentInformationResponse.cs
+++ b/SchoolMedicalServer.Abstractions/Dtos/Student/StudentInformationResponse.cs
@@ -19,5 +19,7 @@
         public string? ParentPhoneNumber { get; set; }
 
         public string? ParentEmailAddress { get; set; }
+
+        public bool ParentAccountCreated { get; set; } = false;
     }
 }

--- a/SchoolMedicalServer.Infrastructure/Services/StudentService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/StudentService.cs
@@ -30,7 +30,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 Grade = s.Grade,
                 Address = s.Address,
                 ParentPhoneNumber = s.ParentPhoneNumber,
-                ParentEmailAddress = s.ParentEmailAddress
+                ParentEmailAddress = s.ParentEmailAddress,
+                ParentAccountCreated = s.UserId.HasValue
             }).ToList();
 
             return new PaginationResponse<StudentInformationResponse>(


### PR DESCRIPTION
Introduced a new boolean property `ParentAccountCreated` in the `StudentInformationResponse` class, defaulting to `false`. Updated the `StudentService` to set this property based on the presence of a `UserId`, indicating whether a parent account has been created for the student.