### PR TITLE
#

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/ManagerDashboardService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/ManagerDashboardService.cs
@@ -19,12 +19,10 @@ namespace SchoolMedicalServer.Infrastructure.Services
             var medicalItems = await medicalInventoryRepository.GetAllAsync();
 
             var today = DateTime.UtcNow.Date;
-            var daysUntilSunday = DayOfWeek.Sunday - today.DayOfWeek;
-            if (daysUntilSunday <= 0) daysUntilSunday += 7;
-            var endOfWeek = today.AddDays(daysUntilSunday);
+            var endOf2Week = today.AddDays(13);
 
             var expiringThisWeek = medicalItems
-                .Where(item => item.ExpiryDate.HasValue && item.ExpiryDate.Value >= today && item.ExpiryDate.Value <= endOfWeek)
+                .Where(item => item.ExpiryDate.HasValue && item.ExpiryDate.Value >= today && item.ExpiryDate.Value <= endOf2Week)
                 .Select(item => new Dictionary<string, MedicalInventoryDashboardResponse>
                 {
                     {

--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationDetailsService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationDetailsService.cs
@@ -130,7 +130,7 @@ namespace SchoolMedicalServer.Infrastructure.Services
         public async Task<IEnumerable<VaccinationDetailsResponse>> GetAllVaccineDetailsAsync()
         {
             var details = await vacctionDetailsRepository.GetAllAsync();
-            details = details.ToList().Where(detail => detail.Status == true).ToList();
+            details = details.ToList().Where(detail => detail.Status == true && detail.ExpirationDate != DateOnly.FromDateTime(DateTime.Now)).ToList();
             return details.Select(detail => MapToResponse(detail)).ToList();
         }
     }


### PR DESCRIPTION
Enhance expiration date filtering in services

Updated `GetExpiringMedicalItemsAsync` to include items expiring within two weeks. Modified `GetAllVaccineDetailsAsync` to exclude details expiring today, improving data accuracy.