### PR TITLE
Swap UserId and SenderId in Notification object

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/VaccinationNotificationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/VaccinationNotificationService.cs
@@ -197,8 +197,8 @@ namespace SchoolMedicalServer.Infrastructure.Services
             var notification = new Notification
             {
                 NotificationId = Guid.NewGuid(),
-                UserId = sender.UserId,
-                SenderId = receiver.UserId,
+                UserId = receiver.UserId,
+                SenderId = sender.UserId,
                 Title = "Vaccination Round Notification",
                 Content = $"A vaccination round has been completed: {round.RoundName} on {round.StartTime?.ToString("d")}.",
                 SendDate = DateTime.UtcNow,


### PR DESCRIPTION
Updated the `VaccinationNotificationService.cs` file to reverse the assignments of the `UserId` and `SenderId` properties in the `Notification` object. Now, `UserId` is set to `receiver.UserId` and `SenderId` to `sender.UserId`.