### PR TITLE
Add handling for received health check status

### DIFF
--- a/SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs
+++ b/SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs
@@ -40,6 +40,10 @@ namespace SchoolMedicalServer.Infrastructure.Services
                 {
                     body = $"Your child {student!.FullName} has successfully completed the health check: {schedule!.HealthCheckType} on {round.StartTime?.ToString("d")}.";
                 }
+                else
+                {
+                    body = $"Your child {student!.FullName} has received the health check: {schedule!.HealthCheckType} on {round.StartTime?.ToString("d")}.";
+                }
 
                 var notification = new Notification
                 {


### PR DESCRIPTION
This pull request introduces a minor update to the `SendHealthCheckNotification` method in `HealthCheckNotificationService.cs`. The change adds an alternative message format for health check notifications.

* [`SchoolMedicalServer.Infrastructure/Services/HealthCheckNotificationService.cs`](diffhunk://#diff-45e7058a12e98303326058cf6e1c777e4d5386535f615ab149fe01c05aabff36R43-R46): Added an `else` block to provide a different notification message when the initial condition is not met.This update introduces an additional conditional branch in the HealthCheckNotificationService to manage cases where the health check status is neither "completed" nor previously handled. A new message is constructed to inform parents that their child has received the health check, including relevant details such as the health check type and date.